### PR TITLE
When cleaning up devices, search in sub-dir of /dev/ is not necessary

### DIFF
--- a/tests/functional/common.rc
+++ b/tests/functional/common.rc
@@ -404,7 +404,7 @@ _cleanup_devices()
         rm -f $d.img
     done
 
-    for d in `find /dev/ -name "loop*"`; do
+    for d in `find /dev/ -maxdepth 1 -name "loop*"`; do
         losetup -d $d &> /dev/null
     done
 }


### PR DESCRIPTION
Otherwise, functional test cases might be failure due to the accessibility of some sub-directories, e.g.
find: `/dev/vboxusb': Permission denied