### PR TITLE
sheepdog proto: avoid using stdint.h macros, so sbd can build.

### DIFF
--- a/include/sheepdog_proto.h
+++ b/include/sheepdog_proto.h
@@ -493,7 +493,7 @@ static inline bool is_data_obj(uint64_t oid)
 static inline size_t count_data_objs(const struct sd_inode *inode)
 {
 	return DIV_ROUND_UP(inode->vdi_size,
-			    (UINT32_C(1) << inode->block_size_shift));
+			    (1UL << inode->block_size_shift));
 }
 
 static inline size_t get_objsize(uint64_t oid, uint32_t object_size)


### PR DESCRIPTION
The Linux kernel headers don't have the *_C suffix macros, so
they can't be used in a header file shared between sheepdog userspace
and the sbd kernel module.