### PR TITLE
Various init script fixups

### DIFF
--- a/script/sheepdog.in
+++ b/script/sheepdog.in
@@ -18,7 +18,8 @@ prog="sheep"
 
 # set secure PATH
 PATH="/sbin:/bin:/usr/sbin:/usr/bin:@SBINDIR@"
-SHEEPDOGD=@SBINDIR@/sheep
+SHEEPDOGD=@SBINDIR@/$prog
+SHEEPDOG_PATH=@LOCALSTATEDIR@/lib/sheepdog 
 
 success()
 {
@@ -51,6 +52,7 @@ fi
 
 # deb based distros
 if [ -d @SYSCONFDIR@/default ]; then
+	[ -s @LIBDIR@/lsb/init-functions ] && . @LIBDIR@/lsb/init-functions
 	[ -f @SYSCONFDIR@/default/$prog ] && . @SYSCONFDIR@/default/$prog
 	[ -z "$LOCK_FILE" ] && LOCK_FILE="@LOCALSTATEDIR@/lock/$prog"
 fi
@@ -84,7 +86,7 @@ start()
 	if status $prog > /dev/null 2>&1; then
 		success
 	else
-		$prog -p 7000 @LOCALSTATEDIR@/lib/sheepdog > /dev/null 2>&1
+		$SHEEPDOGD -p 7000 $SHEEPDOG_PATH > /dev/null 2>&1
 
 		# give it time to fail
 		sleep 2


### PR DESCRIPTION
Source init-functions on deb-based distros to provide killproc.

Use SHEEPDOGD variable in init script

SHEEPDOGD is defined but is not used when starting sheep. This change
allows system default configs to override SHEEPDOGD if desired.

Use SHEEPDOG_PATH in init script

The debian defaults file has a comment that this environment variable
is used by the init script to set the sheepdog storage dir, however
the code in the init script does not support this claim. This change
makes the needed changes that allow this to work.