### PR TITLE
Fix build for 32 bit targets

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -199,6 +199,7 @@ LINT_FLAGS="-weak -unrecog +posixlib +ignoresigns -fcnuse \
 	-badflag -D__gnuc_va_list=va_list -D__attribute\(x\)="
 
 AM_CONDITIONAL(BUILD_SHA1_HW, [[[[ $host = *x86_64* ]]]])
+AM_CONDITIONAL(X86_64,        [[[[ $host = *x86_64* ]]]])
 
 AC_ARG_ENABLE([fatal-warnings],
 	[  --enable-fatal-warnings : enable fatal warnings. ],

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -155,6 +155,12 @@ static inline uint64_t xgetbv(uint32_t idx)
 #define cpu_has_avx		cpu_has(X86_FEATURE_AVX)
 #define cpu_has_osxsave		cpu_has(X86_FEATURE_OSXSAVE)
 
+#else  /* __x86_64__ */
+
+#define cpu_has_ssse3   0
+#define cpu_has_avx     0
+#define cpu_has_osxsave 0
+
 #endif /* __x86_64__ */
 
 #endif	/* SD_COMPILER_H */

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -58,7 +58,7 @@ if !X86_64
 arch = 32
 endif
 
-libsd_a_LIBADD		= $(libsheepdog_a_LIBADD_$(arch))
+libsd_a_LIBADD		= $(libsd_a_LIBADD_$(arch))
 
 if BUILD_SHA1_HW
 libsd_a_SOURCES		+= sha1_ssse3.S

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -38,7 +38,7 @@ libsd_a_SOURCES		= event.c logger.c net.c util.c rbtree.c strbuf.c \
 			  sha1.c option.c work.c sockfd_cache.c fec.c \
 			  sd_inode.c common.c
 
-libsd_a_LIBADD		= isa-l/bin/ec_base.o \
+libsd_a_LIBADD_		= isa-l/bin/ec_base.o \
 			  isa-l/bin/ec_highlevel_func.o \
 			  isa-l/bin/ec_multibinary.o \
 			  isa-l/bin/gf_2vect_dot_prod_sse.o \
@@ -49,6 +49,16 @@ libsd_a_LIBADD		= isa-l/bin/ec_base.o \
 			  isa-l/bin/gf_vect_dot_prod_sse.o \
 			  isa-l/bin/gf_vect_mul_avx.o \
 			  isa-l/bin/gf_vect_mul_sse.o
+
+libsd_a_LIBADD_32	= isa-l/bin/ec_base.o \
+			  isa-l/bin/ec_highlevel_func.o \
+			  isa-l/bin/ec_multibinary.o
+
+if !X86_64
+arch = 32
+endif
+
+libsd_a_LIBADD		= $(libsheepdog_a_LIBADD_$(arch))
 
 if BUILD_SHA1_HW
 libsd_a_SOURCES		+= sha1_ssse3.S
@@ -74,7 +84,7 @@ check-style:
 	@$(CHECK_STYLE) $(libsd_a_SOURCES)
 
 libisa.a:
-	cd isa-l/ && $(MAKE) && cd ..
+	cd isa-l/ && $(MAKE) arch=$(arch) && cd ..
 
 clean-local:
 	rm -f *.o gmon.out *.da *.bb *.bbg

--- a/lib/fec.c
+++ b/lib/fec.c
@@ -739,5 +739,8 @@ void isa_decode_buffer(struct fec *ctx, uint8_t *input[], const int in_idx[],
 
 	lost[0] = (unsigned char *)buf;
 	ec_init_tables(ed, 1, cm, ec_tbl);
-	ec_encode_data_sse(len, ed, 1, ec_tbl, input, lost);
+	if (cpu_has_ssse3)
+		ec_encode_data_sse(len, ed, 1, ec_tbl, input, lost);
+	else
+		ec_encode_data(len, ed, 1, ec_tbl, input, lost);
 }


### PR DESCRIPTION
  * Define CPU flags for non-x86_64 targets
  * Use non-SSE version of ec_encode_data for non-x86_64 targets
  * Add make variable "arch" as it should be used in isa-l