### PR TITLE
MAINTAINERS: add Alexander as a subsystem maintainer of debian relate…

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -70,3 +70,9 @@ Earthquake testing stuff
 M: Hitoshi Mitake <mitake.hitoshi@lab.ntt.co.jp>
 F: tests/earthquake/*
 L: sheepdog@lists.wpkg.org
+
+Debian related stuff
+------------------------------
+M: Alexander Guy <alexander@andern.org>
+F: debian/*
+L: sheepdog@lists.wpkg.org


### PR DESCRIPTION
…d stuff

Alexander is an expert of debian packaging, I'd like to add him
as a maintainer of the debian related subsystem.

Signed-off-by: Hitoshi Mitake <mitake.hitoshi@lab.ntt.co.jp>