### PR TITLE
dog: move dog binary to bin dir instead of sbin

### DIFF
--- a/dog/Makefile.am
+++ b/dog/Makefile.am
@@ -21,7 +21,7 @@ AM_CFLAGS		=
 
 AM_CPPFLAGS		= -I$(top_builddir)/include -I$(top_srcdir)/include
 
-sbin_PROGRAMS		= dog
+bin_PROGRAMS		= dog
 
 dog_SOURCES		= farm/object_tree.c farm/sha1_file.c farm/snap.c \
 			  farm/trunk.c farm/farm.c farm/slice.c \
@@ -49,10 +49,10 @@ dog_LDADD		+= -leq_embed
 endif
 
 install-exec-hook:
-	if [ -z "${DESTDIR}" ];then $(LN_S) -f ${sbindir}/dog ${sbindir}/collie;fi
+	if [ -z "${DESTDIR}" ];then $(LN_S) -f ${bindir}/dog ${bindir}/collie;fi
 
 uninstall-hook:
-	rm -f ${sbindir}/collie
+	rm -f ${sbindir}/collie ${sbindir}/dog
 
 all-local:
 	@echo Built dog


### PR DESCRIPTION
dog binary may be used under non root user, so move it to proper place

Signed-off-by: Vasiliy Tolstov <v.tolstov@selfip.ru>