### PR TITLE
Fix warning, add parentheses around assignment used as truth value

### DIFF
--- a/sheep/cluster/local.c
+++ b/sheep/cluster/local.c
@@ -307,14 +307,14 @@ static int add_event(enum local_event_type type, struct local_node *lnode,
 		xlremove(lnode, ev.lnodes, &ev.nr_lnodes, lnode_cmp);
 		break;
 	case EVENT_GATEWAY:
-		if (n = xlfind(lnode, ev.lnodes, ev.nr_lnodes, lnode_cmp))
+		if ((n = xlfind(lnode, ev.lnodes, ev.nr_lnodes, lnode_cmp)) != NULL)
 			n->gateway = true;
 		break;
 	case EVENT_NOTIFY:
 	case EVENT_BLOCK:
 		break;
 	case EVENT_UPDATE_NODE:
-		if (n = xlfind(lnode, ev.lnodes, ev.nr_lnodes, lnode_cmp))
+		if ((n = xlfind(lnode, ev.lnodes, ev.nr_lnodes, lnode_cmp)) != NULL)
 			n->node = lnode->node;
 		break;
 	case EVENT_ACCEPT:


### PR DESCRIPTION
Fix warning introduced by recent PR:

cluster/local.c: In function 'add_event':
cluster/local.c:310:3: warning: suggest parentheses around assignment used as truth value [-Wparentheses]
   if (n = xlfind(lnode, ev.lnodes, ev.nr_lnodes, lnode_cmp))
   ^
cluster/local.c:317:3: warning: suggest parentheses around assignment used as truth value [-Wparentheses]
   if (n = xlfind(lnode, ev.lnodes, ev.nr_lnodes, lnode_cmp))
   ^