### PR TITLE
isa-l: remove build warning

### DIFF
--- a/include/fec.h
+++ b/include/fec.h
@@ -172,10 +172,13 @@ static inline void ec_encode(struct fec *ctx, const uint8_t *ds[],
 			     uint8_t *ps[])
 {
 	int p = ctx->dp - ctx->d;
+
+#ifndef __x86_64__
 	int pidx[p];
 
 	for (int i = 0; i < p; i++)
 		pidx[i] = ctx->d + i;
+#endif
 
 #ifdef __x86_64__
 		ec_encode_data(SD_EC_DATA_STRIPE_SIZE / ctx->d, ctx->d, p,


### PR DESCRIPTION
This commit removes build warnings like below:

  CC       net.o
In file included from ../include/internal_proto.h:25:0,
                 from ../include/sheep.h:16,
                 from net.c:31:
../include/fec.h: In function ‘ec_encode’:
../include/fec.h:175:6: warning: variable ‘pidx’ set but not used [-Wunused-but-set-variable]
  int pidx[p];

Signed-off-by: Hitoshi Mitake <mitake.hitoshi@lab.ntt.co.jp>