### PR TITLE
decouple node format from cluster format for rolling update

### DIFF
--- a/dog/dog.h
+++ b/dog/dog.h
@@ -18,6 +18,8 @@
 #include <unistd.h>
 #include <sys/ioctl.h>
 #include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
 
 #include "sheepdog_proto.h"
 #include "sheep.h"

--- a/include/internal_proto.h
+++ b/include/internal_proto.h
@@ -255,7 +255,7 @@ struct cluster_info {
 	enum sd_status status : 8;
 	uint8_t block_size_shift;
 	uint8_t __pad[3];
-	uint8_t store[STORE_LEN];
+	uint8_t default_store[STORE_LEN];
 
 	/* Node list at cluster_info->epoch */
 	struct sd_node nodes[SD_MAX_NODES];

--- a/include/internal_proto.h
+++ b/include/internal_proto.h
@@ -240,6 +240,18 @@ struct oid_entry {
 };
 
 /*
+ * node_info: node specific configuration
+ * This is a config data initialized with "dog node format".
+ * Currently, it is very simple so doesn't have different expressions
+ * like cluster_info and sheepdog_config.
+ */
+struct node_info {
+	uint8_t store[STORE_LEN];
+};
+
+#define NODE_CONFIG_PATH "node_config"
+
+/*
  * A joining sheep multicasts the local cluster info.  Then, the existing nodes
  * reply the latest cluster info which is unique among all of the nodes.
  */

--- a/include/sheep.h
+++ b/include/sheep.h
@@ -357,7 +357,7 @@ struct sheepdog_config {
 	uint64_t ctime;
 	uint16_t flags;
 	uint8_t copies;
-	uint8_t store[STORE_LEN];
+	uint8_t default_store[STORE_LEN];
 	uint8_t shutdown;
 	uint8_t copy_policy;
 	uint8_t block_size_shift;

--- a/sheep/config.c
+++ b/sheep/config.c
@@ -13,7 +13,7 @@
 
 static struct sheepdog_config config;
 
-char *config_path;
+char *config_path, *node_config_path;
 
 #define CONFIG_PATH "/config"
 
@@ -60,6 +60,32 @@ static int get_cluster_config(struct cluster_info *cinfo)
 	       sizeof(config.default_store));
 
 	return SD_RES_SUCCESS;
+}
+
+int init_node_config_file(void)
+{
+	int fd, ret;
+	struct stat st;
+
+	ret = stat(node_config_path, &st);
+	if (ret < 0)
+		/* this node doesn't have a node config, do nothing */
+		return 0;
+
+	fd = open(node_config_path, O_RDONLY);
+	if (fd < 0) {
+		sd_err("failed to open node config (%s): %m", node_config_path);
+		return -1;
+	}
+
+	ret = xread(fd, &sys->ninfo, sizeof(sys->ninfo));
+	if (ret != sizeof(sys->ninfo)) {
+		sd_err("failed to read node config (%s): %m", node_config_path);
+		return -1;
+	}
+
+	close(fd);
+	return 0;
 }
 
 int init_config_file(void)
@@ -148,6 +174,10 @@ void init_config_path(const char *base_path)
 
 	config_path = xzalloc(len);
 	snprintf(config_path, len, "%s" CONFIG_PATH, base_path);
+
+	len = strlen(base_path) + strlen(NODE_CONFIG_PATH) + 1;
+	node_config_path = xzalloc(len);
+	snprintf(node_config_path, len, "%s" NODE_CONFIG_PATH, base_path);
 }
 
 int set_cluster_config(const struct cluster_info *cinfo)

--- a/sheep/config.c
+++ b/sheep/config.c
@@ -56,7 +56,8 @@ static int get_cluster_config(struct cluster_info *cinfo)
 			(cinfo->flags & SD_CLUSTER_FLAG_AUTO_VNODES);
 	cinfo->copy_policy = config.copy_policy;
 	cinfo->block_size_shift = config.block_size_shift;
-	memcpy(cinfo->store, config.store, sizeof(config.store));
+	memcpy(cinfo->default_store, config.default_store,
+	       sizeof(config.default_store));
 
 	return SD_RES_SUCCESS;
 }
@@ -156,9 +157,9 @@ int set_cluster_config(const struct cluster_info *cinfo)
 	config.copy_policy = cinfo->copy_policy;
 	config.flags = cinfo->flags;
 	config.block_size_shift = cinfo->block_size_shift;
-	memset(config.store, 0, sizeof(config.store));
-	pstrcpy((char *)config.store, sizeof(config.store),
-		(char *)cinfo->store);
+	memset(config.default_store, 0, sizeof(config.default_store));
+	pstrcpy((char *)config.default_store, sizeof(config.default_store),
+		(char *)cinfo->default_store);
 
 	return write_config();
 }

--- a/sheep/group.c
+++ b/sheep/group.c
@@ -647,13 +647,13 @@ static void setup_backend_store(const struct cluster_info *cinfo)
 {
 	int ret;
 
-	if (cinfo->store[0] == '\0')
+	if (cinfo->default_store[0] == '\0')
 		return;
 
 	if (!sd_store) {
-		sd_store = find_store_driver((char *)cinfo->store);
+		sd_store = find_store_driver((char *)cinfo->default_store);
 		if (!sd_store)
-			panic("backend store %s not supported", cinfo->store);
+			panic("backend store %s not supported", cinfo->default_store);
 
 		ret = sd_store->init();
 		if (ret != SD_RES_SUCCESS)

--- a/sheep/ops.c
+++ b/sheep/ops.c
@@ -306,8 +306,8 @@ static int cluster_make_fs(const struct sd_req *req, struct sd_rsp *rsp,
 		goto out;
 	}
 
-	pstrcpy((char *)sys->cinfo.store, sizeof(sys->cinfo.store),
-		store_name);
+	pstrcpy((char *)sys->cinfo.default_store,
+		sizeof(sys->cinfo.default_store), store_name);
 	sd_store = driver;
 	latest_epoch = get_latest_epoch();
 
@@ -532,7 +532,7 @@ static int local_stat_cluster(struct request *req)
 			elog->copy_policy = sys->cinfo.copy_policy;
 			elog->flags = sys->cinfo.flags;
 			pstrcpy(elog->drv_name, STORE_LEN,
-				(char *)sys->cinfo.store);
+				(char *)sys->cinfo.default_store);
 		}
 
 		elog->epoch = epoch;

--- a/sheep/ops.c
+++ b/sheep/ops.c
@@ -300,7 +300,10 @@ static int cluster_make_fs(const struct sd_req *req, struct sd_rsp *rsp,
 	int32_t nr_vnodes;
 	struct vnode_info *vinfo = get_vnode_info();
 
-	driver = find_store_driver(data);
+	if (strlen((const char *)sys->ninfo.store))
+		driver = find_store_driver((const char *)sys->ninfo.store);
+	else
+		driver = find_store_driver(data);
 	if (!driver) {
 		ret = SD_RES_NO_STORE;
 		goto out;

--- a/sheep/sheep.c
+++ b/sheep/sheep.c
@@ -939,6 +939,10 @@ int main(int argc, char **argv)
 	if (ret)
 		goto cleanup_log;
 
+	ret = init_node_config_file();
+	if (ret)
+		goto cleanup_log;
+
 	ret = init_config_file();
 	if (ret)
 		goto cleanup_log;

--- a/sheep/sheep_priv.h
+++ b/sheep/sheep_priv.h
@@ -131,6 +131,7 @@ struct system_info {
 
 	struct sd_node this_node;
 
+	struct node_info ninfo;
 	struct cluster_info cinfo;
 	enum sd_node_status node_status;
 
@@ -450,6 +451,7 @@ int epoch_log_read_remote(uint32_t epoch, struct sd_node *nodes,
 				struct vnode_info *vinfo);
 uint32_t get_latest_epoch(void);
 void init_config_path(const char *base_path);
+int init_node_config_file(void);
 int init_config_file(void);
 int get_obj_list(const struct sd_req *, struct sd_rsp *, void *);
 int objlist_cache_cleanup(uint32_t vid);

--- a/sheep/store/common.c
+++ b/sheep/store/common.c
@@ -364,7 +364,8 @@ int init_store_driver(bool is_gateway)
 {
 	char driver_name[STORE_LEN], *p;
 
-	pstrcpy(driver_name, sizeof(driver_name), (char *)sys->cinfo.store);
+	pstrcpy(driver_name, sizeof(driver_name),
+		(char *)sys->cinfo.default_store);
 
 	p = memchr(driver_name, '\0', STORE_LEN);
 	if (!p) {

--- a/sheep/store/common.c
+++ b/sheep/store/common.c
@@ -364,8 +364,12 @@ int init_store_driver(bool is_gateway)
 {
 	char driver_name[STORE_LEN], *p;
 
-	pstrcpy(driver_name, sizeof(driver_name),
-		(char *)sys->cinfo.default_store);
+	if (strlen((const char *)sys->ninfo.store))
+		pstrcpy(driver_name, sizeof(driver_name),
+			(char *)sys->ninfo.store);
+	else
+		pstrcpy(driver_name, sizeof(driver_name),
+			(char *)sys->cinfo.default_store);
 
 	p = memchr(driver_name, '\0', STORE_LEN);
 	if (!p) {


### PR DESCRIPTION
This PR is for rolling updating store format. For example, a cluster which starts with plain store can change its store to tree gradually.