### PR TITLE
Remove warning erasure_code/ec_multibinary.asm:255

### DIFF
--- a/lib/isa-l/erasure_code/ec_multibinary.asm
+++ b/lib/isa-l/erasure_code/ec_multibinary.asm
@@ -252,15 +252,6 @@ _done_gf_vect_dot_prod_init:
 	pop	arg1
 	ret
 
-%macro slversion 4
-global %1_slver_%2%3%4
-global %1_slver
-%1_slver:
-%1_slver_%2%3%4:
-	dw 0x%4
-	db 0x%3, 0x%2
-%endmacro
-
 ;;;       func                 		core, ver, snum
 slversion ec_encode_data,		00,   03,  0133
 slversion gf_vect_mul,			00,   02,  0134


### PR DESCRIPTION
Remove warning erasure_code/ec_multibinary.asm:255: warning: redefining multi-line macro `slversion'

Signed-off-by: hongzhou zhang <hongzhou.h.zhang@intel.com>