### PR TITLE
Disable ISA-L if Yasm 1.2.0 or higher is not supported.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -97,11 +97,15 @@ if [[[ $host = *x86_64* ]]]; then
   AC_MSG_CHECKING([checking yasm version])
   AC_LANG_CONFTEST([AC_LANG_SOURCE([[vextracti128 xmm0, ymm0, 0;]])])
   if yasm -f elf64 -i lib/isa-l/include lib/isa-l/erasure_code/gf_vect_dot_prod_avx2.asm -o /dev/null 2> /dev/null ; then
+    yasm_avx2_support=yes
+    AC_DEFINE_UNQUOTED([ENABLE_ISAL], 1, [enable isal])
     AC_MSG_RESULT([yes])
   else
-    AC_MSG_FAILURE([require yasm 1.2.0 or higher])
+    yasm_avx2_support=no
+    AC_MSG_NOTICE([avx2 requires yasm 1.2.0 or higher])
   fi
 fi
+AM_CONDITIONAL(YASM_AVX2_SUPPORT, test "$yasm_avx2_support" = "yes")
 
 # Checks for libraries.
 AC_CHECK_LIB([socket], [socket])

--- a/include/fec.h
+++ b/include/fec.h
@@ -101,8 +101,10 @@ void fec_decode_buffer(struct fec *ctx, uint8_t *input[], const int in_idx[],
 
 /* for isa-l */
 
+#if defined __x86_64__ && defined(ENABLE_ISAL)
 void isa_decode_buffer(struct fec *ctx, uint8_t *input[], const int in_idx[],
 		       char *buf, int idx, uint32_t object_size);
+#endif
 
 /*
  * @param inpkts an array of packets (size k); If a primary block, i, is present
@@ -173,14 +175,14 @@ static inline void ec_encode(struct fec *ctx, const uint8_t *ds[],
 {
 	int p = ctx->dp - ctx->d;
 
-#ifndef __x86_64__
+#if !defined __x86_64__ || !defined(ENABLE_ISAL)
 	int pidx[p];
 
 	for (int i = 0; i < p; i++)
 		pidx[i] = ctx->d + i;
 #endif
 
-#ifdef __x86_64__
+#if defined __x86_64__ && defined(ENABLE_ISAL)
 		ec_encode_data(SD_EC_DATA_STRIPE_SIZE / ctx->d, ctx->d, p,
 				   ctx->ec_tbl, (unsigned char **)ds, ps);
 #else
@@ -212,7 +214,7 @@ static inline void ec_decode_buffer(struct fec *ctx, uint8_t *input[],
 				    const int in_idx[], char *buf,
 				    int idx, uint32_t object_size)
 {
-#ifdef __x86_64__
+#if defined __x86_64__ && defined(ENABLE_ISAL)
 		isa_decode_buffer(ctx, input, in_idx, buf, idx, object_size);
 #else
 		fec_decode_buffer(ctx, input, in_idx, buf, idx, object_size);

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -26,18 +26,27 @@ libsheepdog_a_CPPFLAGS  = $(AM_CPPFLAGS) -DNO_SHEEPDOG_LOGGER
 
 libsd_a_DEPENDENCIES =
 
-noinst_LIBRARIES	= libisa.a libsd.a
+noinst_LIBRARIES	=
 
+if YASM_AVX2_SUPPORT
+noinst_LIBRARIES	+= libisa.a
+endif
+
+noinst_LIBRARIES	+= libsd.a
+
+if YASM_AVX2_SUPPORT
 libisa_a_SOURCES	= $(shell find isa-l/ -type f -regex ".*\.\(c\|h\|asm\)") \
 			  isa-l/erasure_code/Makefile \
 			  isa-l/Makefile \
 			  isa-l/Makefile.nmake \
 			  isa-l/make.inc
+endif
 
 libsd_a_SOURCES		= event.c logger.c net.c util.c rbtree.c strbuf.c \
 			  sha1.c option.c work.c sockfd_cache.c fec.c \
 			  sd_inode.c common.c
 
+if YASM_AVX2_SUPPORT
 libsd_a_LIBADD_		= isa-l/bin/ec_base.o \
 			  isa-l/bin/ec_highlevel_func.o \
 			  isa-l/bin/ec_multibinary.o \
@@ -53,18 +62,21 @@ libsd_a_LIBADD_		= isa-l/bin/ec_base.o \
 			  isa-l/bin/gf_5vect_dot_prod_avx.o \
 			  isa-l/bin/gf_6vect_dot_prod_avx.o \
 			  isa-l/bin/gf_vect_dot_prod_avx.o \
+			  isa-l/bin/gf_vect_mul_avx.o \
+			  isa-l/bin/gf_vect_mul_sse.o \
 			  isa-l/bin/gf_2vect_dot_prod_avx2.o \
 		  	  isa-l/bin/gf_3vect_dot_prod_avx2.o \
 		  	  isa-l/bin/gf_4vect_dot_prod_avx2.o \
 			  isa-l/bin/gf_5vect_dot_prod_avx2.o \
 			  isa-l/bin/gf_6vect_dot_prod_avx2.o \
-			  isa-l/bin/gf_vect_dot_prod_avx2.o \
-			  isa-l/bin/gf_vect_mul_avx.o \
-			  isa-l/bin/gf_vect_mul_sse.o
+			  isa-l/bin/gf_vect_dot_prod_avx2.o
+endif
 
+if YASM_AVX2_SUPPORT
 libsd_a_LIBADD_32	= isa-l/bin/ec_base.o \
 			  isa-l/bin/ec_highlevel_func.o \
 			  isa-l/bin/ec_multibinary.o
+endif
 
 if !X86_64
 arch = 32

--- a/lib/fec.c
+++ b/lib/fec.c
@@ -455,7 +455,7 @@ void fec_free(struct fec *p)
 	sd_assert(p != NULL && p->magic == (((FEC_MAGIC ^ p->d) ^ p->dp) ^
 					 (unsigned long) (p->enc_matrix)));
 	free(p->enc_matrix);
-#ifdef __x86_64__
+#if defined __x86_64__ && defined(ENABLE_ISAL)
 		free(p->ec_tbl);
 #endif
 	free(p);
@@ -498,7 +498,7 @@ struct fec *fec_new(unsigned short d, unsigned short dp)
 		*p = 1;
 	free(tmp_m);
 
-#ifdef __x86_64__
+#if defined __x86_64__ && defined(ENABLE_ISAL)
 		retval->ec_tbl = xmalloc(dp * d * 32);
 		ec_init_tables(d, dp - d, retval->enc_matrix + (d * d),
 			       retval->ec_tbl);
@@ -716,6 +716,7 @@ void fec_decode_buffer(struct fec *ctx, uint8_t *input[], const int in_idx[],
 	}
 }
 
+#if defined __x86_64__ && defined(ENABLE_ISAL)
 void isa_decode_buffer(struct fec *ctx, uint8_t *input[], const int in_idx[],
 		       char *buf, int idx, uint32_t object_size)
 {
@@ -743,3 +744,4 @@ void isa_decode_buffer(struct fec *ctx, uint8_t *input[], const int in_idx[],
 	ec_init_tables(ed, 1, cm, ec_tbl);
 	ec_encode_data(len, ed, 1, ec_tbl, input, lost);
 }
+#endif


### PR DESCRIPTION
This is to guarantee sheepdog can be installed on all x86_64 machines or with old OS.

Signed-off-by: hongzhou zhang <hongzhou.h.zhang@intel.com>