### PR TITLE
sheep/request: fix bug of inconsistency between data_length and data

### DIFF
--- a/sheep/request.c
+++ b/sheep/request.c
@@ -833,7 +833,7 @@ static void rx_main(struct work *work)
 			ci->conn.fd,
 			ci->conn.ipstr, ci->conn.port,
 			op_name(get_sd_op(req->rq.opcode)),
-			data_to_str(req->data, req->rp.data_length));
+			data_to_str(req->data, req->rq.data_length));
 	} else {
 		sd_debug("%d, %s:%d",
 			 ci->conn.fd,


### PR DESCRIPTION
When log admin ops in rx_main, it should use req->rq.data_length
rather than req->rp.data_length. If not, we will always get "not
string" because of req->rp.data_length equals zero.

Signed-off-by: Meng Lingkun <menglingkun@cmss.chinamobile.com>