### PR TITLE
sheep: add more info log for creating and deleting a volume

### DIFF
--- a/sheep/ops.c
+++ b/sheep/ops.c
@@ -129,8 +129,11 @@ static int post_cluster_new_vdi(const struct sd_req *req, struct sd_rsp *rsp,
 {
 	unsigned long nr = rsp->vdi.vdi_id;
 	int ret = rsp->result;
+	char *name = data;
 
-	sd_info("req->vdi.base_vdi_id: %x, rsp->vdi.vdi_id: %x", req->vdi.base_vdi_id, rsp->vdi.vdi_id);
+	sd_info("name: %s, base_vdi_id: %x, new vdi_id: %x, sender: %s",
+		name, req->vdi.base_vdi_id, rsp->vdi.vdi_id,
+		node_to_str(sender));
 
 	sd_debug("done %d %lx", ret, nr);
 	if (ret == SD_RES_SUCCESS)
@@ -194,6 +197,11 @@ static int post_cluster_del_vdi(const struct sd_req *req, struct sd_rsp *rsp,
 	unsigned long vid = rsp->vdi.vdi_id;
 	struct cache_deletion_work *dw;
 	int ret = rsp->result;
+	char *name = data;
+
+	sd_info("name: %s, base_vdi_id: %x, new vdi_id: %x, sender: %s",
+		name, req->vdi.base_vdi_id, rsp->vdi.vdi_id,
+		node_to_str(sender));
 
 	if (ret == SD_RES_SUCCESS) {
 		atomic_set_bit(vid, sys->vdi_deleted);


### PR DESCRIPTION
For the third-party management systems (cinder, etc), they always
record the volume names rather than vid. If the volume is not
deleted, We can get vid from volume name by dog vdi list. However,
if the volume was deleted for some reason, the administrator can't
get vid from volume name when he traces when and what happened to
the volume. Thus, adding volume name and sender information for
creating and deleting is helpful. Sender can guide administrators
to the sender node for detailed information.

Signed-off-by: Meng Lingkun <menglingkun@cmss.chinamobile.com>