### PR TITLE
initial accelio support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -295,6 +295,11 @@ AM_CONDITIONAL(BUILD_LTTNG_UST, test x$enable_lttng_ust = xyes)
 
 AC_ARG_ENABLE(systemd, AS_HELP_STRING([--enable-systemd],[enable systemd support]),enable_systemd=$enableval,enable_systemd="no")
 
+AC_ARG_ENABLE([accelio],
+	[  --enable-accelio         : enable accelio (default no)],,
+	[ enable_accelio=$HAVE_ACCELIO ],)
+AM_CONDITIONAL(BUILD_ACCELIO, test x$enable_accelio = xyes)
+
 dnl systemd detection
 if test x$enable_systemd = xno ; then
     have_systemd=no;
@@ -460,6 +465,13 @@ if test "x${enable_lttng_ust}" = xyes; then
 	PACKAGE_FEATURES="$PACKAGE_FEATURES LTTng-ust"
 fi
 
+if test "x${enable_accelio}" = xyes; then
+	AC_CHECK_HEADERS([libxio.h],,
+		AC_MSG_ERROR(header of accelio not found))
+	AC_DEFINE_UNQUOTED(HAVE_ACCELIO, 1, [have accelio])
+	PACKAGE_FEATURES="$PACKAGE_FEATURES accelio"
+fi
+
 # extra warnings
 EXTRA_WARNINGS=""
 
@@ -541,10 +553,19 @@ else
 	LTTNG_UST_CFLAGS=""
 fi
 
+if test "x${enable_accelio}" = xyes ; then
+	AC_MSG_NOTICE([Enabling Accelio (-lxio)])
+	LIBS+="-lxio"
+	ACCELIO_CFLAGS="-DHAVE_ACCELIO"
+else
+	ACCELIO_CFLAGS=""
+fi
+
 # final build of *FLAGS
 CFLAGS="$ENV_CFLAGS $OPT_CFLAGS $GDB_FLAGS $OS_CFLAGS \
 	$TRACE_CFLAGS $COVERAGE_CFLAGS $EXTRA_WARNINGS $WERROR_CFLAGS \
-	$LTTNG_UST_CFLAGS -D_GNU_SOURCE -D_LGPL_SOURCE -std=gnu99"
+	$LTTNG_UST_CFLAGS $ACCELIO_CFLAGS -D_GNU_SOURCE -D_LGPL_SOURCE \
+	-std=gnu99"
 CPPFLAGS="$ENV_CPPFLAGS $ANSI_CPPFLAGS $OS_CPPFLAGS"
 LDFLAGS="$ENV_LDFLAGS $COVERAGE_LDFLAGS $OS_LDFLAGS"
 

--- a/dog/Makefile.am
+++ b/dog/Makefile.am
@@ -48,6 +48,10 @@ if BUILD_EARTHQUAKE
 dog_LDADD		+= -leq_embed
 endif
 
+if BUILD_ACCELIO
+dog_LDADD		+= -lxio
+endif
+
 install-exec-hook:
 	if [ -z "${DESTDIR}" ];then $(LN_S) -f ${bindir}/dog ${bindir}/collie;fi
 

--- a/dog/common.c
+++ b/dog/common.c
@@ -11,8 +11,9 @@
 
 #include "dog.h"
 #include "sha1.h"
-#include "sockfd_cache.h"
 #include "fec.h"
+
+#include "sockfd_cache.h"
 
 struct timespec get_time_tick(void)
 {
@@ -234,6 +235,13 @@ int dog_exec_req(const struct node_id *nid, struct sd_req *hdr, void *buf)
 	struct sockfd *sfd;
 	int ret;
 
+#ifdef HAVE_ACCELIO
+	if (nid->io_transport_type == IO_TRANSPORT_TYPE_RDMA) {
+		ret = xio_exec_req(nid, hdr, buf, NULL, 0, UINT32_MAX);
+		goto end;
+	}
+#endif
+
 	sfd = sockfd_cache_get(nid);
 	if (!sfd)
 		return -1;
@@ -247,6 +255,7 @@ int dog_exec_req(const struct node_id *nid, struct sd_req *hdr, void *buf)
 
 	sockfd_cache_put(nid, sfd);
 
+end:
 	return ret ? -1 : 0;
 }
 

--- a/dog/dog.c
+++ b/dog/dog.c
@@ -21,6 +21,10 @@
 #include "util.h"
 #include "sockfd_cache.h"
 
+#ifdef HAVE_ACCELIO
+#include "xio.h"
+#endif
+
 #define EPOLL_SIZE 4096
 
 static const char program_name[] = "dog";
@@ -458,6 +462,11 @@ int main(int argc, char **argv)
 	int sdport;
 	struct timespec start, end;
 
+#ifdef HAVE_ACCELIO
+	sd_xio_init();
+	xio_init_main_ctx();
+#endif
+
 	start = get_time_tick();
 
 	log_dog_operation(argc, argv);
@@ -569,10 +578,12 @@ int main(int argc, char **argv)
 		exit(EXIT_SYSFAIL);
 	}
 
+#ifndef HAVE_ACCELIO
 	if (sockfd_init()) {
 		sd_err("sockfd_init() failed");
 		exit(EXIT_SYSFAIL);
 	}
+#endif
 
 	ret = command_fn(argc, argv);
 	if (ret == EXIT_USAGE)

--- a/dog/dog.h
+++ b/dog/dog.h
@@ -31,6 +31,10 @@
 #include "common.h"
 #include "logger.h"
 
+#ifdef HAVE_ACCELIO
+#include "xio.h"
+#endif
+
 #define CMD_NEED_NODELIST (1 << 0)
 #define CMD_NEED_ARG (1 << 1)
 #define CMD_NEED_ROOT (1 << 2)

--- a/include/internal_proto.h
+++ b/include/internal_proto.h
@@ -173,12 +173,22 @@ enum sd_node_status {
 	SD_NODE_STATUS_OK,
 };
 
+#ifdef HAVE_ACCELIO
+#define IO_TRANSPORT_TYPE_TCP 1
+#define IO_TRANSPORT_TYPE_RDMA 2
+#endif
+
 struct node_id {
 	uint8_t addr[16];
 	uint16_t port;
 	uint8_t io_addr[16];
 	uint16_t io_port;
+#ifndef HAVE_ACCELIO
 	uint8_t pad[4];
+#else
+	uint8_t io_transport_type;
+	uint8_t pad[3];
+#endif
 };
 
 struct disk_info {

--- a/include/net.h
+++ b/include/net.h
@@ -33,14 +33,24 @@ struct connection {
 	char ipstr[INET6_ADDRSTRLEN];
 
 	bool dead;
+
+#ifdef HAVE_ACCELIO
+	struct xio_session *session;
+#endif
 };
+
+#ifdef HAVE_ACCELIO
+
+struct sd_xio_session {
+	int efd;
+};
+
+#endif
 
 int conn_tx_off(struct connection *conn);
 int conn_tx_on(struct connection *conn);
 int conn_rx_off(struct connection *conn);
 int conn_rx_on(struct connection *conn);
-int do_read(int sockfd, void *buf, uint32_t len,
-	    bool (*need_retry)(uint32_t), uint32_t, uint32_t);
 int rx(struct connection *conn, enum conn_state next_state);
 int tx(struct connection *conn, enum conn_state next_state);
 int connect_to(const char *name, int port);
@@ -48,6 +58,8 @@ int send_req(int sockfd, struct sd_req *hdr, void *data, unsigned int wlen,
 	     bool (*need_retry)(uint32_t), uint32_t, uint32_t);
 int exec_req(int sockfd, struct sd_req *hdr, void *,
 	     bool (*need_retry)(uint32_t), uint32_t, uint32_t);
+int do_read(int sockfd, void *buf, uint32_t len,
+	    bool (*need_retry)(uint32_t), uint32_t, uint32_t);
 int create_listen_ports(const char *bindaddr, int port,
 			int (*callback)(int fd, void *), void *data);
 int create_unix_domain_socket(const char *unix_path,

--- a/include/xio.h
+++ b/include/xio.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2015 Nippon Telegraph and Telephone Corporation.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version
+ * 2 as published by the Free Software Foundation.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __XIO_H__
+#define __XIO_H__
+
+#include "sheep.h"
+
+#include <libxio.h>
+
+void sd_xio_init(void);
+void sd_xio_shutdown(void);
+
+int xio_exec_req(const struct node_id *nid, struct sd_req *hdr, void *data,
+		 bool (*need_retry)(uint32_t epoch), uint32_t epoch,
+		 uint32_t max_count);
+int xio_send_req(struct node_id *nid, struct sd_req *hdr, void *data,
+		 unsigned int wlen,
+		 bool (*need_retry)(uint32_t), uint32_t, uint32_t);
+int xio_do_read(struct node_id *nid, void *buf, uint32_t len,
+	    bool (*need_retry)(uint32_t), uint32_t, uint32_t);
+int xio_create_listen_ports(const char *bindaddr, int port,
+			    int (*callback)(int fd, void *), bool rdma);
+
+void xio_init_main_ctx(void);
+
+struct xio_context *xio_get_main_ctx(void);
+
+struct xio_connection *sd_xio_gw_create_connection(struct xio_context *ctx,
+						   const struct node_id *nid,
+						   void *user_ctx);
+void xio_gw_send_req(struct xio_connection *conn, struct sd_req *hdr,
+		     void *data, bool (*need_retry)(uint32_t epoch),
+		     uint32_t epoch, uint32_t max_count);
+
+struct xio_forward_info;
+
+struct xio_forward_info_entry {
+	const struct node_id *nid;
+	void *buf;
+	int wlen;
+
+	struct xio_forward_info *fi;
+};
+
+struct xio_forward_info {
+	struct xio_forward_info_entry ent[SD_MAX_NODES];
+	int nr_send, nr_done;
+
+	struct xio_context *ctx;
+};
+
+#endif	/* __XIO_H__ */

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -100,6 +100,10 @@ if BUILD_LTTNG_UST
 libsd_a_SOURCES		+= tracepoint/work_tp.c tracepoint/sockfd_cache_tp.c tracepoint/event_tp.c
 endif
 
+if BUILD_ACCELIO
+libsd_a_SOURCES		+= xio.c
+endif
+
 # support for GNU Flymake
 check-syntax:
 	$(COMPILE) -fsyntax-only $(CHK_SOURCES)

--- a/lib/xio.c
+++ b/lib/xio.c
@@ -1,0 +1,377 @@
+/*
+ * Copyright (C) 2015 Nippon Telegraph and Telephone Corporation.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version
+ * 2 as published by the Free Software Foundation.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <string.h>
+
+#include "sheep.h"
+#include "internal_proto.h"
+#include "rbtree.h"
+#include "event.h"
+#include "work.h"
+#include "xio.h"
+
+#include <libxio.h>
+
+static struct xio_context *main_ctx;
+
+struct xio_context *xio_get_main_ctx(void)
+{
+	return main_ctx;
+}
+
+struct client_data {
+	struct xio_context	*ctx;
+	struct xio_msg *rsp;
+};
+
+static int client_on_response(struct xio_session *session,
+			      struct xio_msg *rsp,
+			      int last_in_rxq,
+			      void *cb_user_context)
+{
+	struct client_data *client_data =
+			(struct client_data *)cb_user_context;
+
+	sd_debug("response on session %p\n", client_data);
+	xio_context_stop_loop(client_data->ctx);
+	client_data->rsp = rsp;
+
+	return 0;
+}
+
+static int on_msg_error(struct xio_session *session,
+			enum xio_status error,
+			enum xio_msg_direction direction,
+			struct xio_msg *msg,
+			void *cb_user_context)
+{
+	/* struct server_data *sdata = (struct server_data *)cb_user_context; */
+
+	if (direction == XIO_MSG_DIRECTION_OUT) {
+		sd_debug("**** [%p] message %lu failed. reason: %s\n",
+		       session, msg->sn, xio_strerror(error));
+	} else {
+		xio_release_response(msg);
+		sd_debug("**** [%p] message %lu failed. reason: %s\n",
+		       session, msg->request->sn, xio_strerror(error));
+	}
+
+	switch (error) {
+	case XIO_E_MSG_FLUSHED:
+		break;
+	default:
+		/* xio_disconnect(sdata->connection); */
+		break;
+	};
+
+	return 0;
+}
+
+static int on_session_event(struct xio_session *session,
+			    struct xio_session_event_data *event_data,
+			    void *cb_user_context)
+{
+	struct client_data *client_data =
+			(struct client_data *)cb_user_context;
+
+	switch (event_data->event) {
+	case XIO_SESSION_CONNECTION_TEARDOWN_EVENT:
+		xio_connection_destroy(event_data->conn);
+		break;
+	case XIO_SESSION_TEARDOWN_EVENT:
+		xio_session_destroy(session);
+		/* xio_context_stop_loop(session_data->ctx);  /\* exit *\/ */
+		break;
+	default:
+		printf("other event: %d\n", event_data->event);
+		break;
+	};
+
+	xio_context_stop_loop(client_data->ctx);
+
+	return 0;
+}
+
+static int client_assign_data_in_buf(struct xio_msg *msg, void *cb_user_context)
+{
+	struct xio_iovec_ex	*sglist = vmsg_sglist(&msg->in);
+	struct xio_reg_mem	in_xbuf;
+
+	sd_debug("assign buffer, msg vec len: %lu", sglist[0].iov_len);
+	if (!sglist[0].iov_len)
+		return 0;
+
+	xio_mem_alloc(sglist[0].iov_len, &in_xbuf);
+
+	sglist[0].iov_base = in_xbuf.addr;
+	sglist[0].mr = in_xbuf.mr;
+
+	return 0;
+}
+
+static struct xio_session_ops client_ses_ops = {
+	.on_session_event = on_session_event,
+	.on_session_established = NULL,
+	.on_msg = client_on_response,
+	.on_msg_error = on_msg_error,
+	.assign_data_in_buf = client_assign_data_in_buf,
+};
+
+static struct xio_connection *sd_xio_create_connection(struct xio_context *ctx,
+					       const struct node_id *nid,
+					       void *user_ctx)
+{
+	struct xio_connection *conn;
+	struct xio_session *session;
+	char url[256];
+	struct xio_session_params params;
+	struct xio_connection_params cparams;
+
+	if (nid->io_transport_type == IO_TRANSPORT_TYPE_RDMA)
+		snprintf(url, 256, "rdma://%s",
+			 addr_to_str(nid->io_addr, nid->io_port));
+	else
+		snprintf(url, 256, "tcp://%s",
+			 addr_to_str(nid->addr, nid->port));
+
+	memset(&params, 0, sizeof(params));
+	params.type = XIO_SESSION_CLIENT;
+	params.ses_ops = &client_ses_ops;
+	params.uri = url;
+	params.user_context = user_ctx;
+
+	session = xio_session_create(&params);
+
+	memset(&cparams, 0, sizeof(cparams));
+	cparams.session = session;
+	cparams.ctx = ctx;
+	cparams.conn_user_context = user_ctx;
+
+	conn = xio_connect(&cparams);
+
+	return conn;
+}
+
+static int client_msg_vec_init(struct xio_msg *msg)
+{
+	msg->in.sgl_type		= XIO_SGL_TYPE_IOV_PTR;
+	msg->in.pdata_iov.max_nents	= 2;
+	msg->in.pdata_iov.sglist	=
+		(struct xio_iovec_ex *)calloc(2, sizeof(struct xio_iovec_ex));
+
+	msg->out.sgl_type		= XIO_SGL_TYPE_IOV_PTR;
+	msg->out.pdata_iov.max_nents	= 1;
+	msg->out.pdata_iov.sglist	=
+		(struct xio_iovec_ex *)calloc(1, sizeof(struct xio_iovec_ex));
+
+	return 0;
+}
+
+static void msg_prep_for_send(struct sd_req *hdr, struct sd_rsp *rsp,
+			      void *data, struct xio_msg *msg)
+{
+	struct xio_vmsg *pomsg = &msg->out;
+	struct xio_iovec_ex *osglist = vmsg_sglist(pomsg);
+	struct xio_vmsg *pimsg = &msg->in;
+	struct xio_iovec_ex *isglist = vmsg_sglist(pimsg);
+
+	vmsg_sglist_set_nents(pomsg, 0);
+	pomsg->header.iov_len = sizeof(*hdr);
+	pomsg->header.iov_base = hdr;
+
+	if (hdr->flags & SD_FLAG_CMD_WRITE) {
+		vmsg_sglist_set_nents(pomsg, 1);
+
+		osglist[0].iov_base = data;
+		osglist[0].iov_len = hdr->data_length;
+		osglist[0].mr = NULL;
+	}
+
+	vmsg_sglist_set_nents(pimsg, 1);
+	isglist[0].iov_base = rsp;
+	isglist[0].iov_len = sizeof(*rsp);
+	isglist[0].mr = NULL;
+
+	if (hdr->data_length) {
+		vmsg_sglist_set_nents(pimsg, 2);
+		isglist[1].iov_base = xzalloc(hdr->data_length);
+		isglist[1].iov_len = hdr->data_length;
+		isglist[1].mr = NULL;
+	}
+}
+
+static void msg_finalize(struct sd_req *hdr, void *data, struct xio_msg *xrsp)
+{
+	struct xio_vmsg *pimsg = &xrsp->in;
+	struct xio_iovec_ex *isglist = vmsg_sglist(pimsg);
+	int nents = vmsg_sglist_nents(pimsg);
+
+	sd_assert(xrsp->in.header.iov_len == sizeof(struct sd_rsp));
+	memcpy(hdr, xrsp->in.header.iov_base, sizeof(*hdr));
+	if (data) {
+		int total = 0;
+
+		for (int i = 0; i < nents; i++) {
+			memcpy((char *)data + total, isglist[i].iov_base,
+			       isglist[i].iov_len);
+			total += isglist[i].iov_len;
+		}
+	}
+
+	xio_release_response(xrsp);
+}
+
+int xio_exec_req(const struct node_id *nid, struct sd_req *hdr, void *data,
+		 bool (*need_retry)(uint32_t epoch), uint32_t epoch,
+		 uint32_t max_count)
+{
+	struct xio_context *ctx = is_main_thread() ?
+		main_ctx : xio_context_create(NULL, 0, -1);
+
+	struct client_data cli = { .ctx = ctx };
+	struct xio_connection *conn = sd_xio_create_connection(ctx, nid, &cli);
+	struct xio_msg xreq;
+	struct sd_rsp rsp;
+
+	memset(&rsp, 0, sizeof(rsp));
+	memset(&xreq, 0, sizeof(xreq));
+	client_msg_vec_init(&xreq);
+	memset(&rsp, 0, sizeof(rsp));
+	msg_prep_for_send(hdr, &rsp, data, &xreq);
+
+	xio_send_request(conn, &xreq);
+	xio_context_run_loop(ctx, XIO_INFINITE);
+
+	msg_finalize(hdr, data, cli.rsp);
+
+	xio_connection_destroy(conn);
+	if (!is_main_thread())
+		xio_context_destroy(ctx);
+
+	return 0;
+}
+
+static int gw_client_on_response(struct xio_session *session,
+				 struct xio_msg *rsp,
+				 int last_in_rxq,
+				 void *cb_user_context)
+{
+	struct xio_forward_info_entry *fi_entry =
+		(struct xio_forward_info_entry *)cb_user_context;
+	struct xio_forward_info *fi = fi_entry->fi;
+
+	struct xio_vmsg *pimsg = &rsp->in;
+	struct xio_iovec_ex *isglist = vmsg_sglist(pimsg);
+
+	int nents = vmsg_sglist_nents(pimsg), total = 0;
+
+	sd_debug("response on fi_entry %p\n", fi_entry);
+
+	for (int i = 0; i < nents; i++) {
+		memcpy((char *)fi_entry->buf + total,
+		       isglist[i].iov_base, isglist[i].iov_len);
+
+		total += isglist[i].iov_len;
+	}
+
+	fi->nr_done++;
+	if (fi->nr_done == fi->nr_send)
+		xio_context_stop_loop(fi->ctx);
+
+	return 0;
+}
+
+static struct xio_session_ops gw_client_ses_ops = {
+	/* .on_session_event = on_session_event, */
+	.on_session_established = NULL,
+	.on_msg = gw_client_on_response,
+	.on_msg_error = on_msg_error,
+	.assign_data_in_buf		= client_assign_data_in_buf,
+};
+
+struct xio_connection *sd_xio_gw_create_connection(struct xio_context *ctx,
+						   const struct node_id *nid,
+						   void *user_ctx)
+{
+	struct xio_connection *conn;
+	struct xio_session *session;
+	char url[256];
+	struct xio_session_params params;
+	struct xio_connection_params cparams;
+
+	if (nid->io_transport_type == IO_TRANSPORT_TYPE_RDMA)
+		snprintf(url, 256, "rdma://%s",
+			 addr_to_str(nid->io_addr, nid->io_port));
+	else
+		snprintf(url, 256, "tcp://%s",
+			 addr_to_str(nid->io_addr, nid->io_port));
+
+	memset(&params, 0, sizeof(params));
+	params.type = XIO_SESSION_CLIENT;
+	params.ses_ops = &gw_client_ses_ops;
+	params.uri = url;
+	params.user_context = user_ctx;
+
+	session = xio_session_create(&params);
+
+	memset(&cparams, 0, sizeof(cparams));
+	cparams.session = session;
+	cparams.ctx = ctx;
+	cparams.conn_user_context = user_ctx;
+
+	conn = xio_connect(&cparams);
+
+	return conn;
+}
+
+void xio_gw_send_req(struct xio_connection *conn, struct sd_req *hdr,
+		     void *data, bool (*need_retry)(uint32_t epoch),
+		     uint32_t epoch, uint32_t max_count)
+{
+	struct xio_msg *xreq = xzalloc(sizeof(*xreq));
+	struct sd_rsp *rsp = xzalloc(sizeof(*rsp));
+
+	client_msg_vec_init(xreq);
+	msg_prep_for_send(hdr, rsp, data, xreq);
+
+	xio_send_request(conn, xreq);
+}
+
+void xio_init_main_ctx(void)
+{
+	/*
+	 * Why do we need this main_ctx?
+	 *
+	 * xio_context_create() changes signal handlers of a calling thread
+	 * internally, so SIGUSR1 fd of local cluster driver cannot work
+	 * if we call xio_context_create() after initializing the driver.
+	 */
+	main_ctx = xio_context_create(NULL, 0, -1);
+}
+
+void sd_xio_init(void)
+{
+	int xopt = 2;		/* hdr + body */
+
+	xio_init();
+
+	xio_set_opt(NULL,
+		    XIO_OPTLEVEL_ACCELIO, XIO_OPTNAME_MAX_IN_IOVLEN,
+		    &xopt, sizeof(int));
+	xio_set_opt(NULL,
+		    XIO_OPTLEVEL_ACCELIO, XIO_OPTNAME_MAX_OUT_IOVLEN,
+		    &xopt, sizeof(int));
+}
+
+void sd_xio_shutdown(void)
+{
+	xio_shutdown();
+}

--- a/sheep/Makefile.am
+++ b/sheep/Makefile.am
@@ -55,6 +55,10 @@ AM_CPPFLAGS		+= -DENABLE_TRACE
 sheep_SOURCES		+= trace/trace.c trace/mcount.S trace/graph.c trace/checker.c
 endif
 
+if BUILD_ACCELIO
+sheep_SOURCES		+= xio.c
+endif
+
 sheep_LDADD	  	= ../lib/libsd.a -lpthread -lm \
 			  $(libacrd_LIBS) $(corosync_LIBS) $(LIBS)
 
@@ -80,6 +84,10 @@ noinst_HEADERS		+=  tracepoint/request_tp.h
 
 if BUILD_LTTNG_UST
 sheep_SOURCES	+= tracepoint/request_tp.c
+endif
+
+if BUILD_ACCELIO
+sheep_LDADD		+= -lxio
 endif
 
 all-local:

--- a/sheep/gateway.c
+++ b/sheep/gateway.c
@@ -12,6 +12,10 @@
 
 #include "sheep_priv.h"
 
+#ifdef HAVE_ACCELIO
+#include "xio.h"
+#endif
+
 static inline void gateway_init_fwd_hdr(struct sd_req *fwd, struct sd_req *hdr)
 {
 	memcpy(fwd, hdr, sizeof(*fwd));
@@ -302,6 +306,8 @@ out:
 	return ret;
 }
 
+#ifndef HAVE_ACCELIO
+
 struct forward_info_entry {
 	struct pollfd pfd;
 	const struct node_id *nid;
@@ -469,22 +475,33 @@ forward_info_advance(struct forward_info *fi, const struct node_id *nid,
 	fi->nr_sent++;
 }
 
+#endif	/* HAVE_ACCELIO */
+
 static int gateway_forward_request(struct request *req)
 {
-	int i, err_ret = SD_RES_SUCCESS, ret;
-	unsigned wlen;
+	int i, err_ret = SD_RES_SUCCESS;
 	uint64_t oid = req->rq.obj.oid;
-	struct forward_info fi;
 	struct sd_req hdr;
 	const struct sd_node *target_nodes[SD_MAX_NODES];
 	int nr_copies = get_req_copy_number(req), nr_reqs, nr_to_send = 0;
 	struct req_iter *reqs = NULL;
 
+#ifdef HAVE_ACCELIO
+	struct xio_context *ctx;
+	struct xio_forward_info xio_fi;
+#else
+	unsigned wlen;
+	int ret;
+	struct forward_info fi;
+#endif
+
 	sd_debug("%"PRIx64, oid);
 
 	gateway_init_fwd_hdr(&hdr, &req->rq);
 	oid_to_nodes(oid, &req->vinfo->vroot, nr_copies, target_nodes);
+#ifndef HAVE_ACCELIO
 	forward_info_init(&fi, nr_copies);
+#endif
 	reqs = prepare_requests(req, &nr_to_send);
 	if (!reqs)
 		return SD_RES_NETWORK_ERROR;
@@ -510,6 +527,8 @@ static int gateway_forward_request(struct request *req)
 		}
 		nr_to_send = ds;
 	}
+
+#ifndef HAVE_ACCELIO
 
 	for (i = 0; i < nr_to_send; i++) {
 		struct sockfd *sfd;
@@ -545,6 +564,44 @@ static int gateway_forward_request(struct request *req)
 		if (ret != SD_RES_SUCCESS)
 			err_ret = ret;
 	}
+
+#else  /* HAVE_ACCELIO */
+
+	ctx = xio_context_create(NULL, 0, -1);
+
+	memset(&xio_fi, 0, sizeof(xio_fi));
+	xio_fi.nr_send = nr_to_send;
+	xio_fi.ctx = ctx;
+
+	for (i = 0; i < nr_to_send; i++) {
+		const struct node_id *nid = &target_nodes[i]->nid;
+		struct xio_forward_info_entry *fi_entry = &xio_fi.ent[i];
+		struct xio_connection *conn;
+		struct sd_req *copied_hdr;
+
+		fi_entry->nid = nid;
+		fi_entry->buf = reqs[i].buf;
+		fi_entry->wlen = reqs[i].wlen;
+		fi_entry->fi = &xio_fi;
+		conn = sd_xio_gw_create_connection(ctx, nid, fi_entry);
+
+		hdr.data_length = reqs[i].dlen;
+		hdr.obj.offset = reqs[i].off;
+		hdr.obj.ec_index = i;
+		hdr.obj.copy_policy = req->rq.obj.copy_policy;
+
+		copied_hdr = xzalloc(sizeof(*copied_hdr));
+		memcpy(copied_hdr, &hdr, sizeof(hdr));
+
+		xio_gw_send_req(conn, copied_hdr, reqs[i].buf, sheep_need_retry,
+				req->rq.epoch, MAX_RETRY_COUNT);
+	}
+
+	xio_context_run_loop(ctx, XIO_INFINITE);
+	xio_context_destroy(ctx);
+
+#endif	/* HAVE_ACCELIO */
+
 out:
 	finish_requests(req, reqs, nr_reqs);
 	return err_ret;

--- a/sheep/request.c
+++ b/sheep/request.c
@@ -13,6 +13,10 @@
 
 #include "sheep_priv.h"
 
+#ifdef HAVE_ACCELIO
+#include "xio.h"
+#endif
+
 #define TRACEPOINT_DEFINE
 #include "request_tp.h"
 
@@ -457,7 +461,7 @@ static main_fn inline void stat_request_end(struct request *req)
 		sys->stat.r.gway_active_nr--;
 }
 
-static void queue_request(struct request *req)
+void queue_request(struct request *req)
 {
 	struct sd_req *hdr = &req->rq;
 	struct sd_rsp *rsp = &req->rp;
@@ -683,8 +687,7 @@ worker_fn int exec_local_req_async(struct sd_req *rq, void *data,
 	return SD_RES_SUCCESS;
 }
 
-static struct request *alloc_request(struct client_info *ci,
-				     uint32_t data_length)
+struct request *alloc_request(struct client_info *ci, uint32_t data_length)
 {
 	struct request *req;
 
@@ -711,7 +714,7 @@ static struct request *alloc_request(struct client_info *ci,
 	return req;
 }
 
-static void free_request(struct request *req)
+void free_request(struct request *req)
 {
 	uatomic_dec(&sys->nr_outstanding_reqs);
 
@@ -745,18 +748,34 @@ main_fn void put_request(struct request *req)
 		} else {
 			list_add_tail(&req->request_list, &ci->done_reqs);
 
-			if (ci->tx_req == NULL)
-				/* There is no request being sent. */
-				if (conn_tx_on(&ci->conn)) {
-					sd_err("switch on sending flag failure, "
-						"connection maybe closed");
-					/*
-					 * should not free_request(req) here
-					 * because it is already in done list
-					 * clear_client_info will free it
-					 */
-					clear_client_info(ci);
-				}
+			switch (ci->type) {
+			case CLIENT_INFO_TYPE_DEFAULT:
+				if (ci->tx_req == NULL)
+					/* There is no request being sent. */
+					if (conn_tx_on(&ci->conn)) {
+						sd_err("switch on sending flag"
+						       " failure, connection"
+						       " maybe closed");
+						/*
+						 * should not free_request(req)
+						 * here because it is already
+						 * in done list
+						 * clear_client_info will free
+						 * it
+						 */
+						clear_client_info(ci);
+					}
+				break;
+#ifdef HAVE_ACCELIO
+			case CLIENT_INFO_TYPE_XIO:
+				xio_send_reply(ci);
+				break;
+#endif
+			default:
+				panic("unknown type of client info: %d",
+				      ci->type);
+				break;
+			}
 		}
 	}
 }
@@ -954,6 +973,8 @@ static struct client_info *create_client(int fd)
 	if (!ci)
 		return NULL;
 
+	ci->type = CLIENT_INFO_TYPE_DEFAULT;
+
 	if (getpeername(fd, (struct sockaddr *)&from, &namesize)) {
 		free(ci);
 		return NULL;
@@ -1121,6 +1142,14 @@ int create_listen_port(const char *bindaddr, int port)
 				   &is_inet_socket);
 }
 
+#ifdef HAVE_ACCELIO
+int xio_create_listen_port(const char *bindaddr, int port, bool rdma)
+{
+	return xio_create_listen_ports(bindaddr, port, create_listen_port_fn,
+				       rdma);
+}
+#endif
+
 int init_unix_domain_socket(const char *dir)
 {
 	static bool is_inet_socket;
@@ -1166,8 +1195,11 @@ worker_fn int sheep_exec_req(const struct node_id *nid, struct sd_req *hdr,
 			     void *buf)
 {
 	struct sd_rsp *rsp = (struct sd_rsp *)hdr;
-	struct sockfd *sfd;
 	int ret;
+
+#ifndef HAVE_ACCELIO
+
+	struct sockfd *sfd;
 
 	sfd = sockfd_cache_get(nid);
 	if (!sfd)
@@ -1188,6 +1220,23 @@ worker_fn int sheep_exec_req(const struct node_id *nid, struct sd_req *hdr,
 				op_name(get_sd_op(hdr->opcode)));
 
 	sockfd_cache_put(nid, sfd);
+
+#else  /* HAVE_ACCELIO */
+
+	ret = xio_exec_req(nid, hdr, buf, sheep_need_retry, hdr->epoch,
+			   MAX_RETRY_COUNT);
+	if (ret) {
+		sd_debug("remote node might have gone away");
+		return SD_RES_NETWORK_ERROR;
+	}
+	ret = rsp->result;
+	if (ret != SD_RES_SUCCESS)
+		sd_warn("failed %s, remote address: %s, op name: %s",
+				sd_strerror(ret),
+				addr_to_str(nid->addr, nid->port),
+				op_name(get_sd_op(hdr->opcode)));
+
+#endif
 	return ret;
 }
 

--- a/sheep/sheep.c
+++ b/sheep/sheep.c
@@ -16,6 +16,10 @@
 #include "trace/trace.h"
 #include "option.h"
 
+#ifdef HAVE_ACCELIO
+#include "xio.h"
+#endif
+
 #define EPOLL_SIZE 4096
 #define DEFAULT_OBJECT_DIR "/tmp"
 #define LOG_FILE_NAME "sheep.log"
@@ -402,9 +406,21 @@ static int ionic_port_parser(const char *s)
 	return 0;
 }
 
+#ifdef HAVE_ACCELIO
+static const char *io_transport;
+static int ionic_transport_parser(const char *s)
+{
+	io_transport = s;
+	return 0;
+}
+#endif
+
 static struct option_parser ionic_parsers[] = {
 	{ "host=", ionic_host_parser },
 	{ "port=", ionic_port_parser },
+#ifdef HAVE_ACCELIO
+	{ "transport=", ionic_transport_parser },
+#endif
 	{ NULL, NULL },
 };
 
@@ -788,6 +804,19 @@ int main(int argc, char **argv)
 					exit(1);
 				}
 			sys->this_node.nid.io_port = io_port;
+#ifdef HAVE_ACCELIO
+			if (!strcmp(io_transport, "tcp"))
+				sys->this_node.nid.io_transport_type =
+					IO_TRANSPORT_TYPE_TCP;
+			else if (!strcmp(io_transport, "rdma"))
+				sys->this_node.nid.io_transport_type =
+					IO_TRANSPORT_TYPE_RDMA;
+			else {
+				sd_err("unknown transport type: %s",
+				       io_transport);
+				exit(1);
+			}
+#endif
 			break;
 		case 'j':
 			uatomic_set_true(&sys->use_journal);
@@ -924,6 +953,11 @@ int main(int argc, char **argv)
 		goto cleanup_dir;
 	}
 
+#ifdef HAVE_ACCELIO
+	sd_xio_init();
+	xio_init_main_ctx();
+#endif
+
 	ret = log_init(program_name, log_dst_type, log_level, log_path);
 	if (ret) {
 		free(argp);
@@ -951,8 +985,24 @@ int main(int argc, char **argv)
 	if (ret)
 		goto cleanup_log;
 
+#ifndef HAVE_ACCELIO
 	if (io_addr && create_listen_port(io_addr, io_port))
 		goto cleanup_log;
+#else
+	if (io_addr) {
+		bool rdma;
+
+		if (!strcmp(io_transport, "rdma"))
+			rdma = true;
+		else {
+			sd_assert(!strcmp(io_transport, "tcp"));
+			rdma = false;
+		}
+
+		if (xio_create_listen_port(io_addr, io_port, rdma))
+			goto cleanup_log;
+	}
+#endif
 
 	ret = init_unix_domain_socket(dir);
 	if (ret)

--- a/sheep/sheep_priv.h
+++ b/sheep/sheep_priv.h
@@ -64,7 +64,16 @@
 #define worker_fn
 #endif
 
+enum client_info_type {
+	CLIENT_INFO_TYPE_DEFAULT = 1,
+#ifdef HAVE_ACCELIO
+	CLIENT_INFO_TYPE_XIO,
+#endif
+};
+
 struct client_info {
+	enum client_info_type type;
+
 	struct connection conn;
 
 	struct request *rx_req;
@@ -76,6 +85,10 @@ struct client_info {
 	struct list_head done_reqs;
 
 	refcnt_t refcnt;
+
+#ifdef HAVE_ACCELIO
+	struct xio_msg *xio_req;
+#endif
 };
 
 enum REQUST_STATUS {
@@ -337,6 +350,9 @@ static inline bool is_aligned_to_pagesize(void *p)
 }
 
 int create_listen_port(const char *bindaddr, int port);
+#ifdef HAVE_ACCELIO
+int xio_create_listen_port(const char *bindaddr, int port, bool rdma);
+#endif
 int init_unix_domain_socket(const char *dir);
 void unregister_listening_fds(void);
 
@@ -640,5 +656,13 @@ int nfs_delete(const char *name);
 #endif
 
 extern bool wildcard_recovery;
+
+struct request *alloc_request(struct client_info *ci, uint32_t data_length);
+void queue_request(struct request *req);
+void free_request(struct request *req);
+
+#ifdef HAVE_ACCELIO
+void xio_send_reply(struct client_info *ci);
+#endif
 
 #endif

--- a/sheep/xio.c
+++ b/sheep/xio.c
@@ -1,0 +1,268 @@
+/*
+ * Copyright (C) 2015 Nippon Telegraph and Telephone Corporation.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version
+ * 2 as published by the Free Software Foundation.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <string.h>
+
+#include "sheep.h"
+#include "internal_proto.h"
+#include "rbtree.h"
+#include "event.h"
+#include "work.h"
+#include "sheep_priv.h"
+
+#include "xio.h"
+
+#include <libxio.h>
+
+/* server private data */
+struct server_data {
+	struct xio_context	*ctx;
+};
+
+static int server_on_request(struct xio_session *session,
+			     struct xio_msg *xio_req,
+			     int last_in_rxq,
+			     void *cb_user_conext)
+{
+	struct client_info *ci;
+	struct sd_req *hdr;
+	struct request *req;
+
+	struct xio_iovec_ex *sglist = vmsg_sglist(&xio_req->in);
+	int nents = vmsg_sglist_nents(&xio_req->in);
+
+	struct xio_session_attr attr;
+
+	memset(&attr, 0, sizeof(attr));
+	xio_query_session(session, &attr, XIO_SESSION_ATTR_USER_CTX);
+	ci = (struct client_info *)attr.user_context;
+
+	sd_debug("on request: %p, %p, nents: %d", session, xio_req, nents);
+	hdr = xio_req->in.header.iov_base;
+	sd_debug("op: 0x%x\n", hdr->opcode);
+
+	req = alloc_request(ci, hdr->data_length);
+	memcpy(&req->rq, hdr, sizeof(req->rq));
+
+	if (hdr->data_length && hdr->flags & SD_FLAG_CMD_WRITE) {
+		sd_assert(nents == 1);
+		req->data = sglist[0].iov_base;
+	}
+
+	xio_req->in.header.iov_base  = NULL;
+	xio_req->in.header.iov_len  = 0;
+	vmsg_sglist_set_nents(&xio_req->in, 0);
+
+	ci->xio_req = xio_req;
+
+	queue_request(req);
+
+	xio_context_stop_loop(xio_get_main_ctx());
+	return 0;
+}
+
+static struct client_info *xio_create_client(struct xio_session *session)
+{
+	struct client_info *ci;
+
+	ci = zalloc(sizeof(*ci));
+	if (!ci)
+		return NULL;
+
+	ci->type = CLIENT_INFO_TYPE_XIO;
+
+	ci->conn.session = session;
+	refcount_set(&ci->refcnt, 0);
+
+	INIT_LIST_HEAD(&ci->done_reqs);
+
+	return ci;
+}
+
+static int server_on_new_session(struct xio_session *session,
+			  struct xio_new_session_req *req,
+			  void *cb_user_context)
+{
+	/* struct sd_xio_session *priv; */
+
+	sd_debug("on new session: %p", session);
+
+	/* priv->efd = eventfd(0, EFD_SEMAPHORE); */
+	xio_accept(session, NULL, 0, NULL, 0);
+
+	xio_context_stop_loop(xio_get_main_ctx());
+}
+
+static int server_on_session_event(struct xio_session *session,
+				   struct xio_session_event_data *event_data,
+				   void *cb_user_context)
+{
+	struct client_info *ci;
+	struct xio_session_attr attr;
+
+	sd_debug("session event: %s. session:%p, connection:%p, reason: %s\n",
+		 xio_session_event_str(event_data->event),
+		 session, event_data->conn,
+		 xio_strerror(event_data->reason));
+
+	switch (event_data->event) {
+	case XIO_SESSION_NEW_CONNECTION_EVENT:
+		memset(&attr, 0, sizeof(attr));
+
+		ci = xio_create_client(session);
+		attr.user_context = ci;
+		xio_modify_session(session, &attr, XIO_SESSION_ATTR_USER_CTX);
+		break;
+	case XIO_SESSION_CONNECTION_TEARDOWN_EVENT:
+		xio_connection_destroy(event_data->conn);
+		break;
+	case XIO_SESSION_TEARDOWN_EVENT:
+		memset(&attr, 0, sizeof(attr));
+
+		xio_query_session(session, &attr, XIO_SESSION_ATTR_USER_CTX);
+		ci = (struct client_info *)attr.user_context;
+
+		xio_session_destroy(session);
+		xio_context_stop_loop(xio_get_main_ctx());
+		break;
+	default:
+		break;
+	};
+
+	xio_context_stop_loop(xio_get_main_ctx());
+	return 0;
+}
+
+static void msg_prep_for_reply(struct sd_rsp *rsp,
+			       void *data, struct xio_msg *msg)
+{
+	struct xio_vmsg *pomsg = &msg->out;
+	struct xio_iovec_ex *sglist = vmsg_sglist(pomsg);
+
+	vmsg_sglist_set_nents(pomsg, 0);
+	pomsg->header.iov_len = sizeof(*rsp);
+	pomsg->header.iov_base = rsp;
+
+	if (rsp->data_length != 0) {
+		vmsg_sglist_set_nents(pomsg, 1);
+
+		sglist[0].iov_base = data;
+		sglist[0].iov_len = rsp->data_length;
+		sglist[0].mr = NULL;
+	}
+}
+
+static int server_msg_vec_init(struct xio_msg *msg)
+{
+	msg->in.sgl_type		= XIO_SGL_TYPE_IOV_PTR;
+	msg->in.pdata_iov.max_nents	= 0;
+	msg->in.pdata_iov.sglist	= NULL;
+
+	msg->out.sgl_type		= XIO_SGL_TYPE_IOV_PTR;
+	msg->out.pdata_iov.max_nents	= 1;
+	msg->out.pdata_iov.sglist	=
+		(struct xio_iovec_ex *)calloc(1, sizeof(struct xio_iovec_ex));
+
+	return 0;
+}
+
+main_fn void xio_send_reply(struct client_info *ci)
+{
+	struct request *req;
+	struct xio_msg xrsp;
+
+	req = list_first_entry(&ci->done_reqs, struct request, request_list);
+	list_del(&req->request_list);
+
+	memset(&xrsp, 0, sizeof(xrsp));
+	server_msg_vec_init(&xrsp);
+
+	msg_prep_for_reply(&req->rp, req->data, &xrsp);
+	xrsp.request = ci->xio_req;
+	xio_send_response(&xrsp);
+
+	xio_context_run_loop(xio_get_main_ctx(), XIO_INFINITE);
+
+	req->data = NULL;	/* the data is owned by xio */
+	free_request(req);
+}
+
+static int server_on_send_response_complete(struct xio_session *session,
+					    struct xio_msg *msg,
+					    void *cb_prv_data)
+{
+	xio_context_stop_loop(xio_get_main_ctx());
+	return 0;
+}
+
+static int server_assign_data_in_buf(struct xio_msg *msg, void *cb_user_context)
+{
+	struct xio_iovec_ex	*sglist = vmsg_sglist(&msg->in);
+	struct xio_reg_mem	in_xbuf;
+
+	sd_debug("assign buffer, msg vec len: %d", sglist[0].iov_len);
+
+	xio_mem_alloc(sglist[0].iov_len, &in_xbuf);
+
+	sglist[0].iov_base = in_xbuf.addr;
+	sglist[0].mr = in_xbuf.mr;
+
+	return 0;
+}
+
+/*---------------------------------------------------------------------------*/
+/* asynchronous callbacks						     */
+/*---------------------------------------------------------------------------*/
+static struct xio_session_ops  portal_server_ops = {
+	.on_session_event		=  server_on_session_event,
+	.on_new_session			=  server_on_new_session,
+	.on_msg_send_complete		=  server_on_send_response_complete,
+	.on_msg				=  server_on_request,
+	.on_msg_error			=  NULL,
+	.assign_data_in_buf		= server_assign_data_in_buf,
+};
+
+static void xio_server_handler(int fd, int events, void *data)
+{
+	struct server_data *server_data = (struct server_data *)data;
+
+	xio_context_poll_wait(server_data->ctx, 0);
+}
+
+int xio_create_listen_ports(const char *bindaddr, int port,
+			    int (*callback)(int fd, void *), bool rdma)
+{
+	char url[256];
+	struct xio_server *server;
+	struct server_data *server_data;
+	int xio_fd;
+
+	server_data = xzalloc(sizeof(*server_data));
+	server_data->ctx = xio_get_main_ctx();
+
+	snprintf(url, 256, rdma ? "rdma://%s:%d" : "tcp://%s:%d",
+		bindaddr ? bindaddr : "0.0.0.0", port);
+	sd_info("accelio binding url: %s", url);
+
+	/* bind a listener server to a portal/url */
+	server = xio_bind(server_data->ctx, &portal_server_ops, url, NULL, 0,
+			  server_data);
+	if (server == NULL) {
+		sd_err("xio_bind() failed");
+		return -1;
+	}
+
+	xio_fd = xio_context_get_poll_fd(server_data->ctx);
+	register_event(xio_fd, xio_server_handler, server_data);
+
+	return 0;
+}
+

--- a/shepherd/Makefile.am
+++ b/shepherd/Makefile.am
@@ -30,6 +30,10 @@ shepherd_DEPENDENCIES	= ../lib/libsd.a
 
 EXTRA_DIST		=
 
+if BUILD_ACCELIO
+shepherd_LDADD		+= -lxio
+endif
+
 lint:
 	-splint $(AM_CPPFLAGS) $(LINT_FLAGS) $(CFLAGS) *.c
 


### PR DESCRIPTION
This patch adds a support of accelio, an library of RPC which wraps
TCP and RDMA in clean way, to sheepdog. With this change, sheepdog
will be able to utilize high speed interconnect like infiniband.

The code is very early stage and have bunch of ToDos. However, I'd
like to share it and want the community to help the implementation.

How to build:
 1. install accelio
 2. ./configure --enable-accelio
 3. make

How to use:
 $ sheep -i transport=rdma,addr=xxx,port=yyy ...

Minor ToDos:
 - clean up code (e.g. comment out)
 - remove known segfault bugs
 - sane error handling
 - remove memory leaks

Major ToDos:
 - enhance code for utilizing RDMA
 - rx/tx in worker threads (I'm not sure it is effective because RDMA
   helps to reduce CPU consumption)

Signed-off-by: Hitoshi Mitake <mitake.hitoshi@lab.ntt.co.jp>