### PR TITLE
sheep/test: include util.h for LOCAL when configure --enable-unittest

### DIFF
--- a/tests/unit/mock/mock.h
+++ b/tests/unit/mock/mock.h
@@ -16,6 +16,7 @@
 
 #include <string.h>
 
+#include "util.h"
 #include "rbtree.h"
 
 struct mock_method {


### PR DESCRIPTION
If not includes util.h, the macro of LOCAL can't be handled, which
will result in compilation fails.

Signed-off-by: Meng Lingkun <menglingkun@cmss.chinamobile.com>