### PR TITLE
tests/functional: adapt to destructive update of pgrep

### DIFF
--- a/tests/functional/common.config
+++ b/tests/functional/common.config
@@ -72,6 +72,11 @@ export SED_PROG="`set_prog_path sed`"
 export BC_PROG="`set_prog_path bc`"
 [ "$BC_PROG" = "" ] && _fatal "bc not found"
 
+PGREP_OPTIONS='-a'
+if pgrep * -a 2>&1 | grep -q "invalid option";then
+        export PGREP_OPTIONS='-l'
+fi
+
 export DRIVER=${DRIVER:-local}
 export WD=${WD:-/tmp/sheepdog}
 export STORE=$WD

--- a/tests/functional/common.config
+++ b/tests/functional/common.config
@@ -74,8 +74,9 @@ export BC_PROG="`set_prog_path bc`"
 
 PGREP_OPTIONS='-a'
 if pgrep * -a 2>&1 | grep -q "invalid option";then
-        export PGREP_OPTIONS='-l'
+    PGREP_OPTIONS='-l'
 fi
+export PGREP_OPTIONS
 
 export DRIVER=${DRIVER:-local}
 export WD=${WD:-/tmp/sheepdog}

--- a/tests/functional/common.rc
+++ b/tests/functional/common.rc
@@ -164,7 +164,7 @@ _cleanup()
 
 _count_sheep_processes()
 {
-    pgrep -f "$SHEEP_PROG $STORE/" -a | awk '{ $1=""; print }' | sort | uniq | wc -l
+    pgrep -f "$SHEEP_PROG $STORE/" $PGREP_OPTIONS | awk '{ $1=""; print }' | sort | uniq | wc -l
 }
 
 # Wait for the specified sheep to be stopped.  If no argument is


### PR DESCRIPTION
As explained in commit 89f6b6a86ff50fe14a6c95b736a346f601d6418c, pgrep
has a destructive update. For sheep, it's better to support the two
different versions. This patch just does this in a simple and maybe
silly way.

Signed-off-by: Meng Lingkun <menglingkun@cmss.chinamobile.com>