### PR TITLE
fix strict_strtoul for never kernels

### DIFF
--- a/sbd/sheep_block_device.c
+++ b/sbd/sheep_block_device.c
@@ -289,8 +289,11 @@ static ssize_t sbd_remove(struct bus_type *bus, const char *buf,
 	struct sbd_device *dev;
 	unsigned long ul;
 	int target_id, ret;
-
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 2, 0)
 	ret = strict_strtoul(buf, 10, &ul);
+#else
+	ret = kstrtoul(buf, 10, &ul);
+#endif
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
strict_strtoul() was just a redefinition of kstrtoul() for a long
time. From kernel version of 3.18, strict_strtoul() will not be
defined at all. A compile time kernel version check is needed to
decide which function or macro can be used for a specific version of
kernel.

Signed-off-by: Vasiliy Tolstov <v.tolstov@selfip.ru>