### PR TITLE
remove inode update prevention

### DIFF
--- a/include/internal_proto.h
+++ b/include/internal_proto.h
@@ -104,8 +104,8 @@
 #define SD_OP_ALTER_VDI_COPY	0xC0
 #define SD_OP_DECREF_OBJ     0xC1
 #define SD_OP_DECREF_PEER    0xC2
-#define SD_OP_PREVENT_INODE_UPDATE    0xC3
-#define SD_OP_ALLOW_INODE_UPDATE      0xC4
+#define SD_OP_PREVENT_INODE_UPDATE    0xC3 /* obsolete */
+#define SD_OP_ALLOW_INODE_UPDATE      0xC4 /* obsolete */
 #define SD_OP_REPAIR_REPLICA	0xC5
 #define SD_OP_OIDS_EXIST	0xC6
 #define SD_OP_VDI_STATE_CHECKPOINT_CTL  0xC7

--- a/lib/shared/vdi.c
+++ b/lib/shared/vdi.c
@@ -320,7 +320,6 @@ static int vdi_read_inode(struct sd_cluster *c, char *name,
 /** FIXME: tgtd multi-path support **/
 int sd_vdi_snapshot(struct sd_cluster *c, char *name, char *snap_tag)
 {
-	struct sd_req hdr = {};
 	char buf[SD_INODE_HEADER_SIZE];
 	struct sd_inode *inode = (struct sd_inode *)buf;
 	int ret = 0;
@@ -357,14 +356,6 @@ int sd_vdi_snapshot(struct sd_cluster *c, char *name, char *snap_tag)
 		return SD_RES_INVALID_PARMS;
 	}
 
-	sd_init_req(&hdr, SD_OP_PREVENT_INODE_UPDATE);
-	ret = sd_run_sdreq(c, &hdr, NULL);
-	if (ret != SD_RES_SUCCESS) {
-		fprintf(stderr, "Failed to prevent inode update: %s\n",
-				sd_strerror(ret));
-		return ret;
-	}
-
 	ret = write_object(c, vid_to_vdi_oid(inode->vdi_id), 0, snap_tag,
 			SD_MAX_VDI_TAG_LEN, offsetof(struct sd_inode, tag), 0,
 			inode->nr_copies, inode->copy_policy, false, false);
@@ -384,12 +375,6 @@ int sd_vdi_snapshot(struct sd_cluster *c, char *name, char *snap_tag)
 	}
 
 out:
-	sd_init_req(&hdr, SD_OP_ALLOW_INODE_UPDATE);
-	int ret2 = sd_run_sdreq(c, &hdr, NULL);
-	if (ret2 != SD_RES_SUCCESS)
-		fprintf(stderr, "allowing inode update failed:%s\n",
-				sd_strerror(ret));
-
 	return ret;
 }
 

--- a/sheep/group.c
+++ b/sheep/group.c
@@ -1436,9 +1436,6 @@ int create_cluster(int port, int64_t zone, int nr_vnodes,
 	if (ret != 0)
 		return -1;
 
-	INIT_LIST_HEAD(&sys->prevented_inode_update_request_queue);
-	INIT_LIST_HEAD(&sys->pending_prevent_inode_update_request_queue);
-
 	return 0;
 }
 

--- a/sheep/ops.c
+++ b/sheep/ops.c
@@ -1315,48 +1315,6 @@ out:
 	return ret;
 }
 
-static int local_prevent_inode_update(const struct sd_req *req,
-				      struct sd_rsp *rsp,
-				      void *data, const struct sd_node *sender)
-{
-	/* FIXME: change type of process_main() */
-	struct request *rq = container_of(req, struct request, rq);
-
-	sd_debug("preventing inode update request, ongoing inode update"
-		 " requests: %d", sys->nr_ongoing_inode_update_request);
-
-	sys->nr_prevent_inode_update++;
-
-	if (sys->nr_ongoing_inode_update_request) {
-		list_add_tail(&rq->pending_prevent_inode_update_reqs,
-			      &sys->pending_prevent_inode_update_request_queue);
-		get_request(rq);
-	}
-
-	return SD_RES_SUCCESS;
-}
-
-static int local_allow_inode_update(const struct sd_req *req,
-				    struct sd_rsp *rsp,
-				    void *data, const struct sd_node *sender)
-{
-	struct request *rq;
-
-	sd_debug("allowing inode update request");
-	sys->nr_prevent_inode_update--;
-
-	if (sys->nr_prevent_inode_update)
-		return SD_RES_SUCCESS;
-
-	list_for_each_entry(rq, &sys->prevented_inode_update_request_queue,
-			    prevented_inode_update_request_list) {
-		list_del(&rq->prevented_inode_update_request_list);
-		requeue_request(rq);
-	}
-
-	return SD_RES_SUCCESS;
-}
-
 static int local_repair_replica(struct request *req)
 {
 	int ret;
@@ -1949,18 +1907,6 @@ static struct sd_op_template sd_ops[] = {
 		.process_work = local_nfs_delete,
 	},
 #endif
-
-	[SD_OP_PREVENT_INODE_UPDATE] = {
-		.name = "PREVENT_INODE_UPDATE",
-		.type = SD_OP_TYPE_LOCAL,
-		.process_main = local_prevent_inode_update,
-	},
-
-	[SD_OP_ALLOW_INODE_UPDATE] = {
-		.name = "ALLOW_INODE_UPDATE",
-		.type = SD_OP_TYPE_LOCAL,
-		.process_main = local_allow_inode_update,
-	},
 
 	[SD_OP_REPAIR_REPLICA] = {
 		.name = "REPAIR_REPLICA",

--- a/sheep/sheep_priv.h
+++ b/sheep/sheep_priv.h
@@ -120,9 +120,6 @@ struct request {
 	struct work work;
 	enum REQUST_STATUS status;
 	bool stat; /* true if this request is during stat */
-
-	struct list_node prevented_inode_update_request_list;
-	struct list_node pending_prevent_inode_update_reqs;
 };
 
 struct system_info {
@@ -176,11 +173,6 @@ struct system_info {
 	/* upgrade data layout before starting service if necessary*/
 	bool upgrade;
 	struct sd_stat stat;
-
-	int nr_prevent_inode_update;
-	int nr_ongoing_inode_update_request;
-	struct list_head prevented_inode_update_request_queue;
-	struct list_head pending_prevent_inode_update_request_queue;
 };
 
 struct disk {


### PR DESCRIPTION
The mechanism of inode update prevention mechanism was introduced in
the commit 449331b4d0c. The original motivation of this mechanism was
for reducing object leak which can happen during taking
snapshot. However, the object leak problem seems to be solved in the
qemu side commit 20760b16b73. I've been kept the mechanism because it
was useful for hiding incomplete state of VDIs (snapshot is created
but new working VDI isn't created yet) from clients. For simplifing
the design of sheepdog, the problem should be handled in the clients.

The retrying mechanism in the qemu driver is already ongoing:
https://github.com/sheepdog/qemu/tree/reconnect-and-reload

Signed-off-by: Hitoshi Mitake <mitake.hitoshi@lab.ntt.co.jp>