### PR TITLE
sheep: write pid before store init and cluster join

### DIFF
--- a/sheep/sheep.c
+++ b/sheep/sheep.c
@@ -844,6 +844,9 @@ int main(int argc, char **argv)
 		}
 	}
 
+	if (!daemonize)
+		pid_file = NULL;
+
 	#ifdef HAVE_DISKVNODES
 	sys->cinfo.flags |= SD_CLUSTER_FLAG_DISKMODE;
 	#endif


### PR DESCRIPTION
some init systems wait for pidfile to continue boot process,
so create it before long tasks.

Signed-off-by: Vasiliy Tolstov v.tolstov@selfip.ru
