### PR TITLE
tests: limit search in sub-directories of /dev

### DIFF
--- a/tests/functional/common.rc
+++ b/tests/functional/common.rc
@@ -442,7 +442,7 @@ _cleanup_devices()
         rm -f $d.img
     done
 
-    for d in `find /dev/ -name "loop*"`; do
+    for d in `find /dev/ -maxdepth 1 -name "loop*"`; do
         losetup -d $d &> /dev/null
     done
 }


### PR DESCRIPTION
When cleaning up devices, search in sub-directories of /dev/
is not necessary

Signed-off-by: Ruoyu <liangry@ucweb.com>
Signed-off-by: Vasiliy Tolstov <v.tolstov@selfip.ru>