### PR TITLE
Fix bash-completion error when using deb package

### DIFF
--- a/debian/sheepdog.bash-completion
+++ b/debian/sheepdog.bash-completion
@@ -1,2 +1,0 @@
-script/bash_completion_dog dog
-script/bash_completion_dog collie


### PR DESCRIPTION
When you install sheepdog via deb package, you will find following error.
This patch delete a unnecessary file.

$ ssh -A ubuntu@10.36.2.55
Welcome to Ubuntu 14.04.3 LTS (GNU/Linux 3.16.0-51-generic x86_64)

 * Documentation:  https://help.ubuntu.com/
Last login: Fri Oct 23 15:30:02 2015 from dhcpfe82.osrg.net
-bash: script/bash_completion_dog: No such file or directory
-bash: script/bash_completion_dog: No such file or directory
-bash: script/bash_completion_dog: No such file or directory
-bash: script/bash_completion_dog: No such file or directory

Signed-off-by: YAMADA Hideki <yamada.hideki@gmail.com>