### PR TITLE
automake: work-around for not expanding variables in _SOURCES.

### DIFF
--- a/tests/unit/dog/Makefile.am
+++ b/tests/unit/dog/Makefile.am
@@ -14,10 +14,17 @@ LIBS			= $(top_srcdir)/lib/libsheepdog.a -lpthread	\
 			  ../mock/libmock.a @CHECK_LIBS@
 
 test_common_SOURCES	= test_common.c mock_dog.c			\
-			  $(top_srcdir)/dog/common.c
+			  dog/common.c
 
 clean-local:
 	rm -f ${check_PROGRAMS} *.o
 
 coverage:
 	@lcov -d . -c -o dog.info
+
+dog/%.c: $(top_srcdir)/dog/%.c
+	@mkdir -p $(@D)
+	@cp $< $@
+
+distclean-local:
+	rm -rf dog

--- a/tests/unit/sheep/Makefile.am
+++ b/tests/unit/sheep/Makefile.am
@@ -14,15 +14,15 @@ LIBS			= $(top_srcdir)/lib/libsheepdog.a		\
 			  @CHECK_LIBS@
 
 test_vdi_SOURCES	= test_vdi.c mock_sheep.c mock_store.c		\
-			  mock_request.c $(top_srcdir)/sheep/vdi.c
+			  mock_request.c sheep/vdi.c
 
 test_cluster_driver_SOURCES	= mock_sheep.c mock_group.c		\
-				  $(top_srcdir)/sheep/cluster/local.c	\
+				  sheep/cluster/local.c	\
 				  test_cluster_driver.c
 test_cluster_driver_CFLAGS	=
 
 if BUILD_ZOOKEEPER
-test_cluster_driver_SOURCES	+= $(top_srcdir)/sheep/cluster/zookeeper.c
+test_cluster_driver_SOURCES	+= sheep/cluster/zookeeper.c
 test_cluster_driver_CFLAGS	+= -DBUILD_ZOOKEEPER
 LIBS += -lzookeeper_mt
 endif
@@ -35,3 +35,10 @@ clean-local:
 
 coverage:
 	@lcov -d . -c -o sheep.info
+
+sheep/%.c: $(top_srcdir)/sheep/%.c
+	@mkdir -p $(@D)
+	@cp $< $@
+
+distclean-local:
+	rm -rf sheep


### PR DESCRIPTION
Common versions of automake have a bug[1] related to enabling
subdir-objects while using variables inside *_SOURCES declarations.

In order to work around these problems with the unit tests, copy
source dependencies locally for building, using GNU make patterns.

[1] http://debbugs.gnu.org/cgi/bugreport.cgi?bug=13928

Signed-off-by: Alexander Guy <alexander@andern.org>
Signed-off-by: Liu Yuan <liuyuan@cmss.chinamobile.com>
Signed-off-by: YAMADA Hideki <yamada.hideki@gmail.com>