### PR TITLE
rpm: fix zookeeper dependencies

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -68,8 +68,7 @@ RPMBUILD_BUILD_REQ_OPTS =
 
 if BUILD_ZOOKEEPER
 RPMBUILD_CONFIG_OPTS += --enable-zookeeper
-RPMBUILD_REQ_OPTS += zookeeper
-RPMBUILD_BUILD_REQ_OPTS += zookeeper-lib-devel
+RPMBUILD_BUILD_REQ_OPTS += zookeeper-native
 endif
 
 if BUILD_SHEEPFS


### PR DESCRIPTION
We don't need zookeeper as runtime dependency, because it can run
on other server.

And we should use Apache Bigtop's zookeeper library package which
are recommended in following JIRA.
The package name is not 'zookeeper-lib-devel'.
It is 'zookeeper-native'.

JIRA:
  - https://issues.apache.org/jira/browse/ZOOKEEPER-2275
  - https://issues.apache.org/jira/browse/ZOOKEEPER-2275

Apache Bigtop Website:
  - http://bigtop.apache.org/

Apache Bigtop Repository:
  - http://www.apache.org/dist/bigtop/bigtop-1.0.0/repos/centos7/bigtop.repo

Signed-off-by: YAMADA Hideki <yamada.hideki@gmail.com>