### PR TITLE
lib/util: remove try_to_free_routine()

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -116,9 +116,6 @@ static inline void *zalloc(size_t size)
 	_x < _y ? -1 : _x > _y ? 1 : 0;	\
 })
 
-typedef void (*try_to_free_t)(size_t);
-try_to_free_t set_try_to_free_routine(try_to_free_t);
-
 void *xmalloc(size_t size);
 void *xzalloc(size_t size);
 void *xrealloc(void *ptr, size_t size);

--- a/lib/util.c
+++ b/lib/util.c
@@ -28,34 +28,11 @@
 mode_t sd_def_dmode = S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IWGRP | S_IXGRP;
 mode_t sd_def_fmode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP;
 
-static void do_nothing(size_t size)
-{
-}
-
-static void (*try_to_free_routine)(size_t size) = do_nothing;
-
-try_to_free_t set_try_to_free_routine(try_to_free_t routine)
-{
-	try_to_free_t old = try_to_free_routine;
-	if (!routine)
-		routine = do_nothing;
-	try_to_free_routine = routine;
-	return old;
-}
-
 void *xmalloc(size_t size)
 {
 	void *ret = malloc(size);
-	if (unlikely(!ret) && unlikely(!size))
-		ret = malloc(1);
-	if (unlikely(!ret)) {
-		try_to_free_routine(size);
-		ret = malloc(size);
-		if (!ret && !size)
-			ret = malloc(1);
-		if (!ret)
-			panic("Out of memory");
-	}
+	if (unlikely(!ret))
+		panic("Out of memory");
 	return ret;
 }
 
@@ -67,32 +44,16 @@ void *xzalloc(size_t size)
 void *xrealloc(void *ptr, size_t size)
 {
 	void *ret = realloc(ptr, size);
-	if (unlikely(!ret) && unlikely(!size))
-		ret = realloc(ptr, 1);
-	if (unlikely(!ret)) {
-		try_to_free_routine(size);
-		ret = realloc(ptr, size);
-		if (!ret && !size)
-			ret = realloc(ptr, 1);
-		if (!ret)
-			panic("Out of memory");
-	}
+	if (unlikely(!ret))
+		panic("Out of memory");
 	return ret;
 }
 
 void *xcalloc(size_t nmemb, size_t size)
 {
 	void *ret = calloc(nmemb, size);
-	if (unlikely(!ret) && unlikely(!nmemb || !size))
-		ret = calloc(1, 1);
-	if (unlikely(!ret)) {
-		try_to_free_routine(nmemb * size);
-		ret = calloc(nmemb, size);
-		if (!ret && (!nmemb || !size))
-			ret = calloc(1, 1);
-		if (!ret)
-			panic("Out of memory");
-	}
+	if (unlikely(!ret))
+		panic("Out of memory");
 	return ret;
 }
 


### PR DESCRIPTION
@mitake Would you review this PR?

```
-----Original Commit Message-----
lib/util: remove try_to_free_routine()

Several memory-allocation functions in lib/util.c call
try_to_free_routine(). The routine is a function pointer. It is initialized
as do_nothing and can be set by set_try_to_free_routine(). However, no one
calls set_try_to_free_routine() in fact. So these code really do nothing.

This removes try_to_free_routine() and related lines.

This closes sheepdog/sheepdog#210.

Signed-off-by: Takashi Menjo <takashi.menjo+github@gmail.com>
`````