### PR TITLE
dog: a new command for benchmarking

### DIFF
--- a/dog/Makefile.am
+++ b/dog/Makefile.am
@@ -26,7 +26,7 @@ bin_PROGRAMS		= dog
 dog_SOURCES		= farm/object_tree.c farm/sha1_file.c farm/snap.c \
 			  farm/trunk.c farm/farm.c farm/slice.c \
 			  dog.c common.c treeview.c vdi.c node.c cluster.c \
-			  upgrade.c
+			  upgrade.c benchmark.c
 
 if BUILD_TRACE
 dog_SOURCES		+= trace.c

--- a/dog/benchmark.c
+++ b/dog/benchmark.c
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2016 Nippon Telegraph and Telephone Corporation.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version
+ * 2 as published by the Free Software Foundation.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <time.h>
+#include <string.h>
+#include <ctype.h>
+#include <sys/time.h>
+
+#include "dog.h"
+#include "sheep.h"
+#include "work.h"
+
+static struct sd_option benchmark_options[] = {
+	{'w', "workqueue", true, "specify workqueue type"},
+	{'f', "force", false, "do not prompt for confirmation"},
+	{'t', "total", true, "a number of total operation (e.g. I/O request)"},
+	{ 0, NULL, false, NULL },
+};
+
+#define DEFAULT_TOTAL 1000
+#define WQ_TYPE_LEN 32
+
+static struct benchmark_cmd_data {
+	char workqueue_type[WQ_TYPE_LEN];
+	bool force;
+	int total;
+} benchmark_cmd_data;
+
+struct benchmark_io_work {
+	struct work work;
+
+	uint32_t vid;
+	uint64_t obj_index, offset;
+	char *buf;
+	int buf_len;
+
+	uint8_t nr_copies, copy_policy;
+};
+
+static void benchmark_io_main(struct work *work)
+{
+	struct benchmark_io_work *io_work;
+	io_work = container_of(work, struct benchmark_io_work, work);
+
+	free(io_work);
+}
+
+static void benchmark_io_worker(struct work *work)
+{
+	struct benchmark_io_work *io_work;
+	uint64_t oid;
+	int ret;
+
+	io_work = container_of(work, struct benchmark_io_work, work);
+	oid = vid_to_data_oid(io_work->vid, io_work->obj_index);
+
+	ret = dog_write_object(oid, 0, io_work->buf, io_work->buf_len,
+			       io_work->offset, 0, io_work->nr_copies,
+			       io_work->copy_policy, false, false);
+	if (ret != SD_RES_SUCCESS) {
+		sd_err("failed to write object %"PRIx64", %s",
+		       oid, sd_strerror(ret));
+		exit(1);
+	}
+}
+
+static int benchmark_io(int argc, char **argv)
+{
+	const char *vdiname = argv[optind++];
+	enum wq_thread_control wq_type = WQ_ORDERED;
+	struct work_queue *wq;
+	int ret, total;
+	struct sd_inode *inode;
+	uint32_t vid;
+	int nr_objects, buf_len;
+	uint64_t obj_index = 0, offset = 0;
+	char *buf;
+
+	if (!benchmark_cmd_data.force)
+		confirm("Caution! benchmark io command will erase all data of"
+			" target VDI.\n Are you sure you want to continue?"
+			" [yes/no]");
+
+	if (strlen(benchmark_cmd_data.workqueue_type) != 0) {
+		if (!strcmp("ordered", benchmark_cmd_data.workqueue_type))
+			wq_type = WQ_ORDERED;
+		else if (!strcmp("dynamic",
+				 benchmark_cmd_data.workqueue_type))
+			wq_type = WQ_DYNAMIC;
+		else if (!strcmp("unlimited",
+				   benchmark_cmd_data.workqueue_type))
+			wq_type = WQ_UNLIMITED;
+		else {
+			sd_err("unknown workqueue type: %s",
+			       benchmark_cmd_data.workqueue_type);
+			sd_err("assumed workqueue types:"
+			       " ordered, dynamic, unlimited");
+			return EXIT_SYSFAIL;
+		}
+	}
+
+	wq = create_work_queue("benchmark", wq_type);
+	if (!wq) {
+		sd_err("failed to create work queue");
+		return EXIT_SYSFAIL;
+	}
+
+	inode = xzalloc(sizeof(*inode));
+
+	ret = read_vdi_obj(vdiname, 0, "", &vid, inode, sizeof(*inode));
+	if (ret != SD_RES_SUCCESS) {
+		sd_err("failed to lookup VDI %s: %s", vdiname, sd_strerror(ret));
+		return EXIT_SYSFAIL;
+	}
+
+	buf_len = 1 << inode->block_size_shift;
+	buf = xzalloc(buf_len);
+
+	nr_objects = inode->vdi_size / (1 << inode->block_size_shift);
+	for (int i = 0; i < nr_objects; i++) {
+		if (inode->data_vdi_id[i] != vid) {
+			sd_err("VDI %s has unallocated data", vdiname);
+			return EXIT_SYSFAIL;
+		}
+	}
+
+	if (benchmark_cmd_data.total != 0)
+		total = benchmark_cmd_data.total;
+	else
+		total = DEFAULT_TOTAL;
+
+	while (0 < total--) {
+		struct benchmark_io_work *w = xzalloc(sizeof(*w));
+
+		w->vid = vid;
+		w->obj_index = (obj_index++) % nr_objects;
+		w->buf = buf;
+		w->buf_len = buf_len;
+		w->offset = offset;
+		w->nr_copies = inode->nr_copies;
+		w->copy_policy = inode->copy_policy;
+
+		w->work.fn = benchmark_io_worker;
+		w->work.done = benchmark_io_main;
+
+		queue_work(wq, &w->work);
+
+		offset += buf_len; /* object size */
+	}
+	work_queue_wait(wq);
+
+	return 0;
+}
+
+static int benchmark_parser(int ch, const char *opt)
+{
+	switch (ch) {
+	case 'w':
+		pstrcpy(benchmark_cmd_data.workqueue_type,
+			sizeof(benchmark_cmd_data.workqueue_type), opt);
+		break;
+	case 'f':
+		benchmark_cmd_data.force = true;
+		break;
+	case 't':
+		benchmark_cmd_data.total = atoi(opt);
+		break;
+	default:
+		sd_err("unknown option: %c", ch);
+		return -1;
+	}
+
+	return 0;
+}
+
+static struct subcommand benchmark_cmd[] = {
+	{"io", "<vdiname>", "aprhTfwt", "benchmark I/O performance",
+	 NULL, CMD_NEED_NODELIST|CMD_NEED_ARG, benchmark_io, benchmark_options},
+	{NULL,},
+};
+
+struct command benchmark_command = {
+	"benchmark",
+	benchmark_cmd,
+	benchmark_parser
+};

--- a/dog/dog.c
+++ b/dog/dog.c
@@ -183,6 +183,7 @@ static void init_commands(const struct command **commands)
 		nfs_command,
 #endif
 		upgrade_command,
+		benchmark_command,
 		{NULL,}
 	};
 

--- a/dog/dog.h
+++ b/dog/dog.h
@@ -121,6 +121,7 @@ extern struct command node_command;
 extern struct command cluster_command;
 extern struct command alter_command;
 extern struct command upgrade_command;
+extern struct command benchmark_command;
 
 #ifdef HAVE_TRACE
 extern struct command trace_command;


### PR DESCRIPTION
This commit adds a new command "benchmark" for easy benchmarking. It
will make performance evaluation easier (e.g. I/O performance,
multicore scalability).

Signed-off-by: Hitoshi Mitake <mitake.hitoshi@lab.ntt.co.jp>