### PR TITLE
sheep/vdi: Fix fill_vdi_state_list() to set 'deleted' member

### DIFF
--- a/sheep/vdi.c
+++ b/sheep/vdi.c
@@ -424,6 +424,7 @@ int fill_vdi_state_list(const struct sd_req *hdr,
 		vs[last].vid = entry->vid;
 		vs[last].nr_copies = entry->nr_copies;
 		vs[last].snapshot = entry->snapshot;
+		vs[last].deleted = entry->deleted;
 		vs[last].copy_policy = entry->copy_policy;
 		vs[last].block_size_shift = entry->block_size_shift;
 		vs[last].lock_state = entry->lock_state;

--- a/tests/unit/sheep/Makefile.am
+++ b/tests/unit/sheep/Makefile.am
@@ -8,6 +8,7 @@ AM_CPPFLAGS		= -I$(top_srcdir)/include			\
 			  -I$(top_srcdir)/sheep				\
 			  -I$(top_srcdir)/sheep/store			\
 			  -I../mock					\
+			  -I../unity/src				\
 			  @CHECK_CFLAGS@
 
 LIBS			= $(top_srcdir)/lib/libsd.a		\
@@ -15,7 +16,7 @@ LIBS			= $(top_srcdir)/lib/libsd.a		\
 			  @CHECK_LIBS@
 
 test_vdi_SOURCES	= test_vdi.c sheep/vdi.c mock_sheep.c mock_store.c		\
-			  mock_request.c
+			  mock_request.c ../unity/src/unity.c
 
 test_cluster_driver_SOURCES	= mock_sheep.c mock_group.c		\
 				  sheep/cluster/local.c	\

--- a/tests/unit/sheep/test_vdi.c
+++ b/tests/unit/sheep/test_vdi.c
@@ -1,7 +1,9 @@
 /*
  * Copyright (C) 2013 Zelin.io
+ * Copyright (C) 2016 Nippon Telegraph and Telephone Corporation
  *
  * Kai Zhang <kyle@zelin.io>
+ * Takashi Menjo <menjo.takashi@lab.ntt.co.jp>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version
@@ -11,42 +13,24 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <check.h>
+#include <unity.h>
 
 #include "sheep_priv.h"
 
-START_TEST(test_vdi)
+static void test_vdi(void)
 {
 	struct system_info mock_sys = {0}; sys = &mock_sys;
 	add_vdi_state(1, 1, true, 0, 22, 0);
 	add_vdi_state(2, 1, true, 0, 22, 0);
 	add_vdi_state(3, 2, false, 0, 22, 0);
-
-	ck_assert_int_eq(get_vdi_copy_number(1), 1);
-	ck_assert_int_eq(get_vdi_copy_number(2), 1);
-	ck_assert_int_eq(get_vdi_copy_number(3), 2);
-}
-END_TEST
-
-static Suite *test_suite(void)
-{
-	Suite *s = suite_create("test vdi");
-
-	TCase *tc_vdi = tcase_create("vdi");
-	tcase_add_test(tc_vdi, test_vdi);
-
-	suite_add_tcase(s, tc_vdi);
-
-	return s;
+	TEST_ASSERT_EQUAL_INT(1, get_vdi_copy_number(1));
+	TEST_ASSERT_EQUAL_INT(1, get_vdi_copy_number(2));
+	TEST_ASSERT_EQUAL_INT(2, get_vdi_copy_number(3));
 }
 
 int main(void)
 {
-	int number_failed;
-	Suite *s = test_suite();
-	SRunner *sr = srunner_create(s);
-	srunner_run_all(sr, CK_NORMAL);
-	number_failed = srunner_ntests_failed(sr);
-	srunner_free(sr);
-	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+	UNITY_BEGIN();
+	RUN_TEST(test_vdi);
+	return UNITY_END();
 }

--- a/tests/unit/sheep/test_vdi.c
+++ b/tests/unit/sheep/test_vdi.c
@@ -69,7 +69,7 @@ static void test_fill_vdi_state_list_should_set_deleted(void)
 	TEST_ASSERT_EQUAL_UINT8(0, state.copy_policy);
 	TEST_ASSERT_EQUAL_UINT8(22, state.block_size_shift);
 	TEST_ASSERT_EQUAL_UINT32(0, state.parent_vid);
-	TEST_ASSERT_TRUE(state.deleted); /* FAIL */
+	TEST_ASSERT_TRUE(state.deleted);
 }
 
 int main(void)


### PR DESCRIPTION
The function ```fill_vdi_state_list()``` implementing ```SD_OP_GET_VDI_COPIES``` should set the ```deleted``` member of ```struct vdi_state``` and respond it.

This is mainly for sheep/group.c:```get_vdis_from()``` because it set VDI bitmap ```sys->vdi_deleted``` based on the value of ```deleted``` member responded by ```SD_OP_GET_VDI_COPIES``` request.

I separate my work into 3 commits. First one refactors related unit tests to use Unity framework. Second one adds unit tests. Third one fixes ```fill_vdi_state_list()```.

Fixes #234.