### PR TITLE
Increment participant count after updating all state

### DIFF
--- a/sheep/vdi.c
+++ b/sheep/vdi.c
@@ -594,11 +594,12 @@ static bool add_new_participant(struct vdi_state_entry *entry,
 		return false;
 	}
 
-	idx = entry->nr_participants++;
+	idx = entry->nr_participants;
 	memcpy(&entry->participants[idx], owner, sizeof(*owner));
 	entry->participants_state[idx] =
 		is_modified(entry) ?
 		SHARED_LOCK_STATE_INVALIDATED : SHARED_LOCK_STATE_SHARED;
+	entry->nr_participants++;
 
 	sd_debug("new participant %s (%d) joined to VID: %"PRIx32", state is %d",
 		 node_id_to_str(&entry->participants[idx]), idx, entry->vid,


### PR DESCRIPTION
This code increments the nr_participants but the participant state is not updated yet. The is_modified will now iterate over the updated nr_participants and can see bad state in participant_state array.
This PR increments participant counter after the participant state is updated.