### PR TITLE
tests: Add operation test

### DIFF
--- a/tests/operation/README.md
+++ b/tests/operation/README.md
@@ -1,0 +1,13 @@
+# Operation tests
+This directory contains **operation tests**, for testing `SD_OP_*` operations.
+Tests are written with PyUnit framework.
+
+## To add tests
+Edit or add `test_*.py`.
+
+## To add operations
+Edit `SheepdogClient` class in `sheep.py`.
+If a new C struct is needed, add a corresponding Python class using Struct.
+
+## To add fixtures
+Edit `fixture.py`.

--- a/tests/operation/fixture.py
+++ b/tests/operation/fixture.py
@@ -1,0 +1,223 @@
+import os
+import subprocess
+import tempfile
+
+
+def MakeZeroFile(nbSize):
+    (fd, path) = tempfile.mkstemp()
+    fh = os.fdopen(fd, "w")
+    fh.truncate(nbSize)
+    fh.close()
+    return path
+
+
+def MakeXFS(path):
+    args = ["mkfs.xfs", "-ssize=4096", "-f", path]
+    subprocess.check_call(args)
+    return True
+
+
+def MountLoopbackXFS(path, mnt):
+    args = ["sudo", "mount", "-oloop,noatime", "-t", "xfs", path, mnt]
+    subprocess.check_call(args)
+    return True
+
+
+def UnmountFS(mnt):
+    args = ["sudo", "umount", mnt]
+    subprocess.check_call(args)
+    return True
+
+
+def CreateSheepdogDisk(nbSize):
+    img = MakeZeroFile(nbSize)
+    try:
+        MakeXFS(img)
+    except:
+        try:
+            os.unlink(img)
+        except:
+            pass
+        raise
+
+    mnt = tempfile.mkdtemp()
+    try:
+        MountLoopbackXFS(img, mnt)
+    except:
+        try:
+            os.rmdir(mnt)
+            os.unlink(img)
+        except:
+            pass
+        raise
+
+    return (img, mnt)
+
+
+def DestroySheepdogDisk(img, mnt):
+    UnmountFS(mnt)
+    os.rmdir(mnt)
+    os.unlink(img)
+    return True
+
+
+def MakeDisksArg(disks):
+    disksType = type(disks)
+    if disksType == str:
+        return disks
+    if disksType in (tuple, list):
+        return ",".join(disks)
+    return None
+
+
+def StartSheep(disks, port=None, zone=None, cluster=None):
+    disksArg = MakeDisksArg(disks)
+    if disksArg is None:
+        raise ValueError
+    cmd = ["sudo", "sheep"]
+    if port is not None:
+        cmd.append("--port")
+        cmd.append(str(port))
+    if zone is not None:
+        cmd.append("--zone")
+        cmd.append(str(zone))
+    if cluster is not None:
+        cmd.append("--cluster")
+        cmd.append(cluster)
+    cmd.append(disksArg)
+    subprocess.check_call(cmd)
+    return True
+
+
+def KillLocalNode(port):
+    cmd = ["dog", "node", "kill", "--local", "--port", str(port)]
+    subprocess.check_call(cmd)
+    return True
+
+
+def ForceFormatCluster(copies, port=None):
+    cmd = ["dog", "cluster", "format", "--force"]
+    if port is not None:
+        cmd.append("--port")
+        cmd.append(str(port))
+    cmd.append("--copies")
+    cmd.append(str(copies))
+    subprocess.check_call(cmd)
+    return True
+
+
+def ShutdownCluster(port=None):
+    cmd = ["dog", "cluster", "shutdown"]
+    if port is not None:
+        cmd.append("--port")
+        cmd.append(str(port))
+    subprocess.check_call(cmd)
+    return True
+
+
+def CreateVDI(name, nb_size=4194304, prealloc=False, port=None):
+    cmd = ["dog", "vdi", "create"]
+    if port is not None:
+        cmd.append("--port")
+        cmd.append(str(port))
+    if prealloc:
+        cmd.append("--prealloc")
+    cmd.append(name)
+    cmd.append(str(nb_size))
+    subprocess.check_call(cmd)
+    return True
+
+
+def DeleteVDI(name, tag=None, port=None):
+    cmd = ["dog", "vdi", "delete"]
+    if port is not None:
+        cmd.append("--port")
+        cmd.append(str(port))
+    if tag is not None:
+        cmd.append("--snapshot")
+        cmd.append(tag)
+    cmd.append(name)
+    subprocess.check_call(cmd)
+    return True
+
+
+def ListVDI(port=None):
+    cmd = ["dog", "vdi", "list", "--raw"]
+    if port is not None:
+        cmd.append("--port")
+        cmd.append(str(port))
+
+    out = subprocess.check_output(cmd)
+    if len(out) == 0:
+        return []
+
+    vdis = []
+    for s in out.rstrip("\n").split("\n"):
+        c = s.split(" ")
+        v = {"snapshot": (c[0] == "s"),
+             "cloned": (c[0] == "c"),
+             "name": c[1],
+             "nb_size": int(c[3]),
+             "vdi_id": int(c[7], 16),
+             "copies": int(c[8]),
+             "tag": c[9],
+             "block_size_shift": int(c[10])}
+        vdis.append(v)
+
+    return vdis
+
+
+def WriteVDI(name, content, port=None):
+    cmd = ["dog", "vdi", "write"]
+    if port is not None:
+        cmd.append("--port")
+        cmd.append(str(port))
+    cmd.append(name)
+
+    dog = subprocess.Popen(cmd, stdin=subprocess.PIPE)
+    dog.communicate(input=content)
+    if dog.returncode != 0:
+        raise CalledProcessError(dog.returncode)
+
+    return True
+
+
+def ReadVDI(name, tag=None, offset=None, length=None, port=None):
+    cmd = ["dog", "vdi", "read"]
+    if port is not None:
+        cmd.append("--port")
+        cmd.append(str(port))
+    if tag is not None:
+        cmd.append("--snapshot")
+        cmd.append(tag)
+    cmd.append(name)
+    if offset is not None:
+        cmd.append(str(offset))
+        if length is not None:
+            cmd.append(str(length))
+    return subprocess.check_output(cmd)
+
+
+def SnapshotVDI(name, tag, port=None):
+    cmd = ["dog", "vdi", "snapshot"]
+    if port is not None:
+        cmd.append("--port")
+        cmd.append(str(port))
+    cmd.append("--snapshot")
+    cmd.append(tag)
+    cmd.append(name)
+    subprocess.check_call(cmd)
+    return True
+
+
+def CloneVDI(src, tag, dst, port=None):
+    cmd = ["dog", "vdi", "clone"]
+    if port is not None:
+        cmd.append("--port")
+        cmd.append(str(port))
+    cmd.append("--snapshot")
+    cmd.append(tag)
+    cmd.append(src)
+    cmd.append(dst)
+    subprocess.check_call(cmd)
+    return True

--- a/tests/operation/proto.py
+++ b/tests/operation/proto.py
@@ -1,0 +1,103 @@
+SD_PROTO_VER = 0x02
+SD_SHEEP_PROTO_VER = 0x0a
+
+SD_EC_MAX_STRIP = 16
+SD_MAX_COPIES = SD_EC_MAX_STRIP * 2 - 1
+
+SD_OP_CREATE_AND_WRITE_OBJ  = 0x01
+SD_OP_READ_OBJ       = 0x02
+SD_OP_WRITE_OBJ      = 0x03
+SD_OP_REMOVE_OBJ     = 0x04
+SD_OP_DISCARD_OBJ    = 0x05
+
+SD_OP_NEW_VDI        = 0x11
+SD_OP_LOCK_VDI       = 0x12
+SD_OP_RELEASE_VDI    = 0x13
+SD_OP_GET_VDI_INFO   = 0x14
+SD_OP_READ_VDIS      = 0x15
+SD_OP_FLUSH_VDI      = 0x16
+SD_OP_DEL_VDI        = 0x17
+SD_OP_GET_CLUSTER_DEFAULT   = 0x18
+
+SD_OP_GET_VDI_COPIES = 0xAB
+SD_OP_READ_DEL_VDIS  = 0xC9
+
+# macros in the SD_FLAG_CMD_XXX group are mutually exclusive
+SD_FLAG_CMD_WRITE    = 0x01
+SD_FLAG_CMD_COW      = 0x02
+SD_FLAG_CMD_CACHE    = 0x04
+SD_FLAG_CMD_DIRECT   = 0x08 # don't use object cache
+# return something back while sending something to sheep
+SD_FLAG_CMD_PIGGYBACK   = 0x10
+SD_FLAG_CMD_TGT   = 0x20
+
+SD_RES_SUCCESS       = 0x00 # Success
+SD_RES_UNKNOWN       = 0x01 # Unknown error
+SD_RES_NO_OBJ        = 0x02 # No object found
+SD_RES_EIO           = 0x03 # I/O error
+SD_RES_VDI_EXIST     = 0x04 # VDI exists already
+SD_RES_INVALID_PARMS = 0x05 # Invalid parameters
+SD_RES_SYSTEM_ERROR  = 0x06 # System error
+SD_RES_VDI_LOCKED    = 0x07 # VDI is locked
+SD_RES_NO_VDI        = 0x08 # No VDI found
+SD_RES_NO_BASE_VDI   = 0x09 # No base VDI found
+SD_RES_VDI_READ      = 0x0A # Cannot read requested VDI
+SD_RES_VDI_WRITE     = 0x0B # Cannot write requested VDI
+SD_RES_BASE_VDI_READ = 0x0C # Cannot read base VDI
+SD_RES_BASE_VDI_WRITE   = 0x0D # Cannot write base VDI
+SD_RES_NO_TAG        = 0x0E # Requested tag is not found
+SD_RES_STARTUP       = 0x0F # Sheepdog is on starting up
+SD_RES_VDI_NOT_LOCKED   = 0x10 # VDI is not locked
+SD_RES_SHUTDOWN      = 0x11 # Sheepdog is shutting down
+SD_RES_NO_MEM        = 0x12 # Cannot allocate memory
+SD_RES_FULL_VDI      = 0x13 # we already have the maximum VDIs
+SD_RES_VER_MISMATCH  = 0x14 # Protocol version mismatch
+SD_RES_NO_SPACE      = 0x15 # Server has no room for new objects
+SD_RES_WAIT_FOR_FORMAT  = 0x16 # Sheepdog is waiting for a format operation
+SD_RES_WAIT_FOR_JOIN = 0x17 # Sheepdog is waiting for other nodes joining
+SD_RES_JOIN_FAILED   = 0x18 # Target node had failed to join sheepdog
+SD_RES_HALT          = 0x19 # Sheepdog is stopped doing IO
+SD_RES_READONLY      = 0x1A # Object is read-only
+# inode object in client is invalidated, refreshing is required
+SD_RES_INODE_INVALIDATED = 0x1D
+
+# Object ID rules
+#
+#  0 - 31 (32 bits): data object space
+# 32 - 55 (24 bits): VDI object space
+# 56 - 59 ( 4 bits): reserved VDI object space
+# 60 - 63 ( 4 bits): object type identifier space
+VDI_SPACE_SHIFT = 32
+SD_VDI_MASK = 0x00FFFFFF00000000
+VDI_BIT = 1 << 63
+VMSTATE_BIT = 1 << 62
+VDI_ATTR_BIT = 1 << 61
+VDI_BTREE_BIT = 1 << 60
+LEDGER_BIT = 1 << 59
+OLD_MAX_DATA_OBJS = 1 << 20
+MAX_DATA_OBJS = 1 << 32
+SD_MAX_VDI_LEN = 256
+SD_MAX_VDI_TAG_LEN = 256
+SD_MAX_VDI_ATTR_KEY_LEN = 256
+SD_MAX_VDI_ATTR_VALUE_LEN = 65536
+SD_MAX_SNAPSHOT_TAG_LEN = 256
+SD_NR_VDIS = 1 << 24
+SD_DATA_OBJ_SIZE = 1 << 22
+SD_OLD_MAX_VDI_SIZE = (SD_DATA_OBJ_SIZE * OLD_MAX_DATA_OBJS)
+SD_MAX_VDI_SIZE = (SD_DATA_OBJ_SIZE * MAX_DATA_OBJS)
+SD_DEFAULT_BLOCK_SIZE_SHIFT = 22
+
+SD_LEDGER_OBJ_SIZE = 1 << 22
+CURRENT_VDI_ID = 0
+
+STORE_LEN = 16
+
+SD_REQ_SIZE = 48
+SD_RSP_SIZE = 48
+
+LOCK_TYPE_NORMAL = 0
+LOCK_TYPE_SHARED = 1  # for iSCSI multipath
+
+
+def vid_to_vdi_oid(vid):
+    return VDI_BIT | vid << VDI_SPACE_SHIFT

--- a/tests/operation/sheep.py
+++ b/tests/operation/sheep.py
@@ -1,0 +1,360 @@
+import struct
+import socket
+import datetime
+import random
+import hashlib
+
+import proto
+
+
+class Connection(object):
+
+    def __init__(self, host, port):
+        self.host = host
+        self.port = port
+        self._sock = socket.create_connection((host, port))
+
+    def sendall(self, data):
+        return self._sock.sendall(data)
+
+    def recvall(self, totalsize):
+        data = ''
+        received = 0
+        while received < totalsize:
+            bufsize = min(4096, totalsize - received)
+            buf = self._sock.recv(bufsize)
+            received += len(buf)
+            data += buf
+        return data
+
+
+class Inode(object):
+    fmt = '<256s256sQQQQQBBBBLLLL4092x1048576L2097152L'
+    size = struct.calcsize(fmt)
+    packer = struct.Struct(fmt)
+
+    def __init__(self, data):
+        assert self.size == len(data)
+        self.data = data
+        pieces = self.packer.unpack(data)
+
+        name = pieces[0]
+        length = name.index('\0')
+        self.name = name[:length]
+
+        self.tag = pieces[1]
+        self.create_time = pieces[2] >> 32
+        self.snap_ctime = pieces[3] >> 32
+        self.vm_clock_nsec = pieces[4]
+        self.vdi_size = pieces[5]
+        self.vm_state_size = pieces[6]
+        self.copy_policy = pieces[7]
+        self.store_policy = pieces[8]
+        self.nr_copies = pieces[9]
+        self.block_size_shift = pieces[10]
+        self.snap_id = pieces[11]
+        self.vdi_id = pieces[12]
+        self.parent_vdi_id = pieces[13]
+        self.btree_counter = pieces[14]
+
+        self.data_vdi_id = pieces[15:1048591]
+        self.generation_reference = pieces[1048591:3145728]
+
+
+class VDIState(object):
+    #   40 = sizeof(struct node_id)
+    #   31 = SD_MAX_COPIES
+    # 1240 = sizeof(struct node_id) * SD_MAX_COPIES
+    fmt = '<LBBBBB3xLL40xL31L1240x'
+    size = struct.calcsize(fmt)
+    packer = struct.Struct(fmt)
+
+    def __init__(self, data):
+        assert self.size == len(data)
+        self.data = data
+        pieces = self.packer.unpack(data)
+
+        self.vid = pieces[0]
+        self.nr_copies = pieces[1]
+        self.snapshot = pieces[2]
+        self.deleted = pieces[3]
+        self.copy_policy = pieces[4]
+        self.block_size_shift = pieces[5]
+        self.parent_vid = pieces[6]
+        self.lock_state = pieces[7]
+        self.nr_participants = pieces[8]
+        self.participants_state = pieces[9:40]
+
+
+class Request(object):
+    fmt = '<BBHLLL32x'
+    size = struct.calcsize(fmt)
+    packer = struct.Struct(fmt)
+    OBJ_OPS = (
+        proto.SD_OP_CREATE_AND_WRITE_OBJ,
+        proto.SD_OP_READ_OBJ,
+        proto.SD_OP_WRITE_OBJ,
+        proto.SD_OP_REMOVE_OBJ,
+        proto.SD_OP_DISCARD_OBJ,
+    )
+    VDI_OPS = (
+        proto.SD_OP_NEW_VDI,
+        proto.SD_OP_LOCK_VDI,
+        proto.SD_OP_RELEASE_VDI,
+        proto.SD_OP_GET_VDI_INFO,
+        proto.SD_OP_READ_VDIS,
+        proto.SD_OP_FLUSH_VDI,
+        proto.SD_OP_DEL_VDI,
+        proto.SD_OP_GET_CLUSTER_DEFAULT,
+    )
+
+    def __init__(self):
+        self.proto_ver = proto.SD_PROTO_VER
+        self.opcode = 0x00
+        self.flags = 0x00
+        self.epoch = 0
+        self.id = 0
+        self.data_length = 0
+        self.obj = self.Object()
+        self.vdi = self.VDI()
+        self.data = ''
+
+    def serialize(self):
+        data = self.packer.pack(
+            self.proto_ver, self.opcode, self.flags,
+            self.epoch,
+            self.id,
+            self.data_length)
+        if self.opcode in self.OBJ_OPS:
+            data = data[:16] + self.obj.serialize()
+        elif self.opcode in self.VDI_OPS:
+            data = data[:16] + self.vdi.serialize()
+        if self.flags & proto.SD_FLAG_CMD_WRITE != 0:
+            data += self.data
+        return data
+
+    class Object(object):
+        fmt = '<QQBBBBLLL'
+        size = struct.calcsize(fmt)
+        packer = struct.Struct(fmt)
+
+        def __init__(self):
+            self.oid = 0x00000000
+            self.cow_oid = 0x00000000
+            self.copies = 0
+            self.copy_policy = 0
+            self.ec_index = 0
+            self.tgt_epoch = 0
+            self.offset = 0
+
+        def serialize(self):
+            return self.packer.pack(
+                self.oid,
+                self.cow_oid,
+                self.copies, self.copy_policy, self.ec_index, 0,
+                self.tgt_epoch,
+                self.offset,
+                0)
+
+    class VDI(object):
+        fmt = '<QLBBBBLL8x'
+        size = struct.calcsize(fmt)
+        packer = struct.Struct(fmt)
+
+        def __init__(self):
+            self.vdi_size = 0
+            self.base_vdi_id = 0
+            self.copies = 0
+            self.copy_policy = 0
+            self.store_policy = 0
+            self.block_size_shift = 0
+            self.snapid = 0
+            self.type = 0
+
+        def serialize(self):
+            return self.packer.pack(
+                self.vdi_size,
+                self.base_vdi_id,
+                self.copies, self.copy_policy,
+                self.store_policy, self.block_size_shift,
+                self.snapid,
+                self.type,
+            )
+
+
+class Response(object):
+    fmt = '<BBHLLLL28x'
+    size = struct.calcsize(fmt)
+    packer = struct.Struct(fmt)
+
+    def __init__(self, data):
+        pieces = self.packer.unpack(data)
+        self.proto_ver = pieces[0]
+        self.opcode = pieces[1]
+        self.flags = pieces[2]
+        self.epoch = pieces[3]
+        self.id = pieces[4]
+        self.data_length = pieces[5]
+        self.result = pieces[6]
+        self.data = ''
+
+        self.vdi = self.VDI(data[20:48])
+
+    class VDI(object):
+        fmt = '<4xLLBB2x12x'
+        size = struct.calcsize(fmt)
+        packer = struct.Struct(fmt)
+
+        def __init__(self, data):
+            pieces = self.packer.unpack(data)
+            self.vdi_id = pieces[0]
+            self.attr_id = pieces[1]
+            self.copies = pieces[2]
+            self.block_size_shift = pieces[3]
+
+
+class SheepdogClient(object):
+    UINT32_MAX = 2 ** 32
+
+    def __init__(self, host="127.0.0.1", port=7000):
+        self._conn = Connection(host, port)
+        self._seq_id = random.randint(1, self.UINT32_MAX - 1)
+
+    def _call(self, req):
+        self._seq_id = (self._seq_id + 1) % self.UINT32_MAX
+        req.id = self._seq_id
+        self._conn.sendall(req.serialize())
+        rsp = Response(self._conn.recvall(Response.size))
+        assert req.id == rsp.id
+        if rsp.result == proto.SD_RES_SUCCESS:
+            rsp.data = self._conn.recvall(rsp.data_length)
+        else:
+            raise Exception(hex(rsp.result))
+        return rsp
+
+    def _parse_vid_bitmap(self, data):
+        vids = set()
+        for i, c in enumerate(data):
+            if c != '\x00':
+                (b,) = struct.unpack('<B', c)
+                j = 0
+                while b & 255 > 0:
+                    if b & 1 == 1:
+                        vids.add(i * 8 + j)
+                    j += 1
+                    b = b >> 1
+        return vids
+
+    def _parse_vdi_state(self, data):
+        assert len(data) % 1428 == 0
+        nr_vdis = len(data) / 1428
+        status = []
+        for i in range(nr_vdis):
+            head = 1428 * i
+            tail = 1428 * (i + 1)
+            status.append(VDIState(data[head:tail]))
+        return status
+
+    def get_vids(self):
+        req = Request()
+        req.opcode = proto.SD_OP_READ_VDIS
+        req.data_length = proto.SD_NR_VDIS / 8
+        rsp = self._call(req)
+        return self._parse_vid_bitmap(rsp.data)
+
+    def get_del_vids(self):
+        req = Request()
+        req.opcode = proto.SD_OP_READ_DEL_VDIS
+        req.proto_ver = proto.SD_SHEEP_PROTO_VER
+        req.data_length = proto.SD_NR_VDIS / 8
+        rsp = self._call(req)
+        return self._parse_vid_bitmap(rsp.data)
+
+    def read_obj(self, oid, offset, size):
+        req = Request()
+        req.opcode = proto.SD_OP_READ_OBJ
+        req.data_length = size
+        req.obj.oid = oid
+        req.obj.offset = offset
+        return self._call(req)
+
+    def get_vdi_copies(self, epoch):
+        req = Request()
+        req.opcode = proto.SD_OP_GET_VDI_COPIES
+        req.proto_ver = proto.SD_SHEEP_PROTO_VER
+        req.data_length = 1428 * 512
+        req.epoch = epoch
+        rsp = self._call(req)
+        return self._parse_vdi_state(rsp.data)
+
+    def get_inode(self, vid):
+        rsp = self.read_obj(proto.vid_to_vdi_oid(vid), 0, Inode.size)
+        return Inode(rsp.data)
+
+    def get_inodes(self):
+        inodes = []
+        for vid in self.get_vids():
+            inode = self.get_inode(vid)
+            if not inode.name:
+                continue
+            inodes.append(inode)
+        return inodes
+
+    def find_inode(self, vdiname, tagname=''):
+        req = Request()
+        req.opcode = proto.SD_OP_GET_VDI_INFO
+        req.flags = proto.SD_FLAG_CMD_WRITE
+        req.data_length = 512
+        req.data = struct.pack('<256s256s', vdiname, tagname)
+        rsp = self._call(req)
+        return self.get_inode(rsp.vdi.vdi_id)
+
+    def find_vdi(self, vdiname):
+        return SheepdogVDI(self, self.find_inode(vdiname))
+
+
+class SheepdogVDI(object):
+
+    def __init__(self, client, inode):
+        self.client = client
+        self.inode = inode
+        self.object_size = 1 << self.inode.block_size_shift
+
+    def read(self, offset, length):
+        data = ''
+        iterator = self.OffsetIterator(offset, length, self.object_size)
+        for idx, offset, length in iterator:
+            vdi_id = self.inode.data_vdi_id[idx]
+            if vdi_id == 0:
+                data = '\0' * length
+                continue
+            oid = (vdi_id << proto.VDI_SPACE_SHIFT) + idx
+            rsp = self.client.read_obj(oid, offset, length)
+            data += rsp.data
+        return data
+
+    class OffsetIterator(object):
+
+        def __init__(self, offset, length, object_size):
+            self.idx = int(offset / object_size)
+            self.offset = offset % object_size
+            self.total = length
+            self.done = 0
+            self.object_size = object_size
+
+        def __iter__(self):
+            return self
+
+        def next(self):
+            if self.total <= self.done:
+                raise StopIteration()
+
+            length = min(self.total - self.done,
+                         self.object_size - self.offset)
+            ret = (self.idx, self.offset, length)
+
+            self.offset = 0
+            self.idx += 1
+            self.done += length
+
+            return ret

--- a/tests/operation/test_3nodes_2copies.py
+++ b/tests/operation/test_3nodes_2copies.py
@@ -1,0 +1,270 @@
+import unittest
+
+import hashlib
+import os
+import os.path
+import subprocess
+import tempfile
+import time
+
+import fixture
+import sheep
+
+
+class ThreeNodesTwoCopiesTest(unittest.TestCase):
+    _NR_NODES = 3
+    _COPIES = 2
+    _ports = []
+    _disks = []
+
+    @classmethod
+    def setUpClass(clazz):
+        for i in range(clazz._NR_NODES):
+            t = fixture.CreateSheepdogDisk(1024 ** 3)
+            p = i + 7000
+            z = i + 1
+            fixture.StartSheep(t[1], port=p, zone=z)
+            clazz._ports.append(p)
+            clazz._disks.append(t)
+        time.sleep(2)
+
+    @classmethod
+    def tearDownClass(clazz):
+        fixture.ShutdownCluster()
+        time.sleep(2)
+        for t in clazz._disks:
+            fixture.DestroySheepdogDisk(t[0], t[1])
+
+    def _assertUnique(self, function, iterable):
+        filtered = filter(function, iterable)
+        self.assertEqual(1, len(filtered))
+        return filtered[0]
+
+    def _assertUniqueName(self, name, iterable):
+        return self._assertUnique(lambda x: x["name"] == name, iterable)
+
+    def setUp(self):
+        fixture.ForceFormatCluster(self.__class__._COPIES)
+
+    def testReadObj(self):
+        NB_OBJECT = 1 << 22
+        NB_VDI = NB_OBJECT * 4
+        assert NB_VDI % NB_OBJECT == 0
+
+        self.assertTrue(fixture.CreateVDI("alpha", NB_VDI))
+
+        alpha = self._assertUniqueName("alpha", fixture.ListVDI())
+        self.assertEqual(NB_VDI, alpha["nb_size"])
+        a_vid = alpha["vdi_id"]
+
+        contentToWrite = os.urandom(NB_VDI)
+        self.assertEqual(NB_VDI, len(contentToWrite))
+        self.assertTrue(fixture.WriteVDI("alpha", contentToWrite))
+
+        for p in self.__class__._ports:
+            client = sheep.SheepdogClient(port=p)
+            for i in range(NB_VDI / NB_OBJECT):
+                oid = (a_vid << 32) | i
+                response = client.read_obj(oid, 0, NB_OBJECT)
+                contentRead = response.data
+                self.assertEqual(NB_OBJECT, len(contentRead))
+
+                s = NB_OBJECT * i
+                e = NB_OBJECT * (i + 1)
+
+                expected = hashlib.md5(contentToWrite[s:e]).digest()
+                actual = hashlib.md5(contentRead).digest()
+                self.assertEqual(expected, actual)
+
+    def testReadObjOffset(self):
+        NB_OBJECT = 1 << 22
+        NB_SUBOBJECT = NB_OBJECT / 4
+        assert NB_OBJECT % NB_SUBOBJECT == 0
+
+        self.assertTrue(fixture.CreateVDI("alpha", NB_OBJECT))
+
+        alpha = self._assertUniqueName("alpha", fixture.ListVDI())
+        self.assertEqual(NB_OBJECT, alpha["nb_size"])
+        a_vid = alpha["vdi_id"]
+        oid = a_vid << 32
+
+        contentToWrite = os.urandom(NB_OBJECT)
+        self.assertEqual(NB_OBJECT, len(contentToWrite))
+        self.assertTrue(fixture.WriteVDI("alpha", contentToWrite))
+
+        for p in self.__class__._ports:
+            client = sheep.SheepdogClient(port=p)
+            for i in range(NB_OBJECT / NB_SUBOBJECT):
+                s = NB_SUBOBJECT * i
+                e = NB_SUBOBJECT * (i + 1)
+
+                response = client.read_obj(oid, s, NB_SUBOBJECT)
+                contentRead = response.data
+                self.assertEqual(NB_SUBOBJECT, len(contentRead))
+
+                expected = hashlib.md5(contentToWrite[s:e]).digest()
+                actual = hashlib.md5(contentRead).digest()
+                self.assertEqual(expected, actual)
+
+    def testGetVDICopies(self):
+        self.assertTrue(fixture.CreateVDI("alpha"))
+        self.assertTrue(fixture.CreateVDI("bravo"))
+
+        vdis = fixture.ListVDI()
+        self.assertEqual(2, len(vdis))
+
+        alpha = self._assertUniqueName("alpha", vdis)
+        a_vid = alpha["vdi_id"]
+        bravo = self._assertUniqueName("bravo", vdis)
+        b_vid = bravo["vdi_id"]
+
+        for p in self.__class__._ports:
+            client = sheep.SheepdogClient(port=p)
+            status = client.get_vdi_copies(1)
+            self.assertEqual(2, len(status))
+
+            a_state = self._assertUnique(lambda x: x.vid == a_vid, status)
+            self.assertEqual(2, a_state.nr_copies)
+            self.assertEqual(0, a_state.snapshot)
+            self.assertEqual(0, a_state.deleted)
+            self.assertEqual(0, a_state.copy_policy)
+            self.assertEqual(22, a_state.block_size_shift)
+            self.assertEqual(0, a_state.parent_vid)
+
+            b_state = self._assertUnique(lambda x: x.vid == b_vid, status)
+            self.assertEqual(2, b_state.nr_copies)
+            self.assertEqual(0, b_state.snapshot)
+            self.assertEqual(0, b_state.deleted)
+            self.assertEqual(0, b_state.copy_policy)
+            self.assertEqual(22, b_state.block_size_shift)
+            self.assertEqual(0, b_state.parent_vid)
+
+    def testGetVDICopiesDeleted(self):
+        self.assertTrue(fixture.CreateVDI("alpha"))
+        self.assertTrue(fixture.DeleteVDI("alpha"))
+        self.assertEqual(0, len(fixture.ListVDI()))
+
+        for p in self.__class__._ports:
+            client = sheep.SheepdogClient(port=p)
+            status = client.get_vdi_copies(1)
+            a_state = self._assertUnique(None, status)
+            self.assertEqual(1, a_state.deleted)
+
+    def testGetVDICopiesSnapshot(self):
+        self.assertTrue(fixture.CreateVDI("alpha"))
+        self.assertTrue(fixture.SnapshotVDI("alpha", "alpha_1"))
+
+        vdis = fixture.ListVDI()
+        self.assertEqual(2, len(vdis))
+
+        alpha = self._assertUnique(lambda x: not x["snapshot"], vdis)
+        self.assertEqual("alpha", alpha["name"])
+        a_vid = alpha["vdi_id"]
+
+        snap = self._assertUnique(lambda x: x["snapshot"], vdis)
+        self.assertEqual("alpha", snap["name"])
+        self.assertEqual("alpha_1", snap["tag"])
+        s_vid = snap["vdi_id"]
+
+        for p in self.__class__._ports:
+            client = sheep.SheepdogClient(port=p)
+            status = client.get_vdi_copies(1)
+            self.assertEqual(2, len(status))
+
+            a_state = self._assertUnique(lambda x: x.vid == a_vid, status)
+            self.assertEqual(2, a_state.nr_copies)
+            self.assertEqual(0, a_state.snapshot)
+            self.assertEqual(0, a_state.deleted)
+            self.assertEqual(0, a_state.copy_policy)
+            self.assertEqual(22, a_state.block_size_shift)
+            self.assertEqual(s_vid, a_state.parent_vid)
+
+            s_state = self._assertUnique(lambda x: x.vid == s_vid, status)
+            self.assertEqual(2, s_state.nr_copies)
+            self.assertEqual(1, s_state.snapshot)
+            self.assertEqual(0, s_state.deleted)
+            self.assertEqual(0, s_state.copy_policy)
+            self.assertEqual(22, s_state.block_size_shift)
+            self.assertEqual(0, s_state.parent_vid)
+
+    def testReadVDIs(self):
+        self.assertTrue(fixture.CreateVDI("alpha"))
+        self.assertTrue(fixture.SnapshotVDI("alpha", "alpha_1"))
+
+        vdis = fixture.ListVDI()
+        self.assertEqual(2, len(vdis))
+
+        alpha = self._assertUnique(lambda x: not x["snapshot"], vdis)
+        self.assertEqual("alpha", alpha["name"])
+        a_vid = alpha["vdi_id"]
+
+        snap = self._assertUnique(lambda x: x["snapshot"], vdis)
+        self.assertEqual("alpha", snap["name"])
+        self.assertEqual("alpha_1", snap["tag"])
+        s_vid = snap["vdi_id"]
+
+        for p in self.__class__._ports:
+            client = sheep.SheepdogClient(port=p)
+            inuse = client.get_vids()
+            self.assertEqual(2, len(inuse))
+            self.assertTrue(a_vid in inuse)
+            self.assertTrue(s_vid in inuse)
+
+    def testReadDelVDIs(self):
+        self.assertTrue(fixture.CreateVDI("alpha"))
+        alpha = self._assertUniqueName("alpha", fixture.ListVDI())
+        a_vid = alpha["vdi_id"]
+
+        self.assertTrue(fixture.DeleteVDI("alpha"))
+        self.assertEqual(0, len(fixture.ListVDI()))
+
+        for p in self.__class__._ports:
+            client = sheep.SheepdogClient(port=p)
+            deleted = client.get_del_vids()
+            self.assertEqual(1, len(deleted))
+            self.assertTrue(a_vid in deleted)
+
+    def testGetVDIsFrom(self):
+        self.assertTrue(fixture.CreateVDI("alpha"))
+        self.assertTrue(fixture.CreateVDI("bravo"))
+        vdis = fixture.ListVDI()
+        self.assertEqual(2, len(vdis))
+
+        alpha = self._assertUniqueName("alpha", vdis)
+        a_vid = alpha["vdi_id"]
+        bravo = self._assertUniqueName("bravo", vdis)
+        b_vid = bravo["vdi_id"]
+
+        self.assertTrue(fixture.DeleteVDI("bravo"))
+        self.assertEqual(1, len(fixture.ListVDI()))
+
+        for p in self.__class__._ports:
+            client = sheep.SheepdogClient(port=p)
+
+            # before
+            status = client.get_vdi_copies(1)
+            self.assertEqual(2, len(status))
+            a_state = self._assertUnique(lambda x: x.vid == a_vid, status)
+            b_state = self._assertUnique(lambda x: x.vid == b_vid, status)
+            self.assertEqual(1, b_state.deleted)
+
+            # after
+            deleted = client.get_del_vids()
+            self.assertEqual(1, len(deleted))
+            self.assertTrue(a_vid not in deleted)
+            self.assertTrue(b_vid in deleted)
+            inuse = client.get_vids()
+            self.assertTrue(a_vid in inuse)
+            a_inode = client.get_inode(a_vid)
+
+            self.assertEqual(a_state.nr_copies, a_inode.nr_copies)
+            self.assertEqual(bool(a_state.snapshot), bool(a_inode.snap_ctime))
+            self.assertEqual(a_state.copy_policy, a_inode.copy_policy)
+            self.assertEqual(
+                a_state.block_size_shift,
+                a_inode.block_size_shift)
+            self.assertEqual(a_state.parent_vid, a_inode.parent_vdi_id)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/operation/test_fixture.py
+++ b/tests/operation/test_fixture.py
@@ -1,0 +1,235 @@
+import unittest
+
+import hashlib
+import os
+import os.path
+import subprocess
+import tempfile
+import time
+
+import fixture
+
+
+class FileSystemTest(unittest.TestCase):
+
+    def setUp(self):
+        self._path = None
+
+    def tearDown(self):
+        try:
+            if self._path is not None:
+                os.unlink(self._path)
+        except:
+            pass
+
+    def testMakeZeroFile0(self):
+        self._path = fixture.MakeZeroFile(0)
+        self.assertIsNotNone(self._path)
+        self.assertEquals(0, os.stat(self._path).st_size)
+
+    def testMakeZeroFile1(self):
+        self._path = fixture.MakeZeroFile(1)
+        self.assertIsNotNone(self._path)
+        self.assertEquals(1, os.stat(self._path).st_size)
+
+    def testMakeZeroFile1G(self):
+        self._path = fixture.MakeZeroFile(1024**3)
+        self.assertIsNotNone(self._path)
+        self.assertEquals(1024**3, os.stat(self._path).st_size)
+
+    def testMakeXFS(self):
+        self._path = fixture.MakeZeroFile(1024**3)
+        self.assertIsNotNone(self._path)
+        self.assertTrue(fixture.MakeXFS(self._path))
+
+
+class StoreTest(unittest.TestCase):
+
+    def setUp(self):
+        self._img = None
+        self._mnt = None
+
+    def tearDown(self):
+        try:
+            if self._mnt is not None:
+                os.rmdir(self._mnt)
+            if self._img is not None:
+                os.unlink(self._img)
+        except:
+            pass
+
+    def testMountAndUnmount(self):
+        self._img = fixture.MakeZeroFile(1024**3)
+        self.assertIsNotNone(self._img)
+        self.assertTrue(fixture.MakeXFS(self._img))
+        self._mnt = tempfile.mkdtemp()
+        self.assertIsNotNone(self._mnt)
+        self.assertTrue(fixture.MountLoopbackXFS(self._img, self._mnt))
+        self.assertTrue(fixture.UnmountFS(self._mnt))
+
+    def testCreateAndDestroy(self):
+        (self._img, self._mnt) = fixture.CreateSheepdogDisk(1024**3)
+        self.assertIsNotNone(self._img)
+        self.assertIsNotNone(self._mnt)
+        self.assertTrue(os.path.isfile(self._img))
+        self.assertTrue(os.path.isdir(self._mnt))
+        self.assertEquals(1024**3, os.stat(self._img).st_size)
+        self.assertTrue(fixture.DestroySheepdogDisk(self._img, self._mnt))
+        (self._img, self._mnt) = (None, None)
+
+
+class NodeAndClusterTest(unittest.TestCase):
+
+    def setUp(self):
+        self._disks = []
+
+    def tearDown(self):
+        for t in self._disks:
+            fixture.DestroySheepdogDisk(t[0], t[1])
+
+    def _SheepExists(self):
+        return (subprocess.call(["sudo", "pgrep", "sheep"]) == 0)
+
+    def testStartAndKillNode(self):
+        self.assertFalse(self._SheepExists())
+        t = fixture.CreateSheepdogDisk(1024**3)
+        self.assertIsNotNone(t)
+        self.assertTrue(fixture.StartSheep(t[1]))
+        self._disks.append(t)
+        time.sleep(2)
+        self.assertTrue(self._SheepExists())
+        self.assertTrue(fixture.KillLocalNode(7000))
+        time.sleep(2)
+        self.assertFalse(self._SheepExists())
+
+    def testFormatAndShutdownCluster(self):
+        self.assertEquals(1, subprocess.call(["sudo", "pgrep", "sheep"]))
+        for i in range(3):
+            t = fixture.CreateSheepdogDisk(1024**3)
+            p = i + 7000
+            z = i + 1
+            self.assertTrue(fixture.StartSheep(t[1], port=p, zone=z))
+            self._disks.append(t)
+        time.sleep(2)
+        self.assertEquals(0, subprocess.call(["sudo", "pgrep", "sheep"]))
+        self.assertTrue(fixture.ForceFormatCluster(3))
+        self.assertTrue(fixture.ShutdownCluster())
+        time.sleep(2)
+        self.assertEquals(1, subprocess.call(["sudo", "pgrep", "sheep"]))
+
+
+class VDITest(unittest.TestCase):
+
+    def setUp(self):
+        self._disks = []
+        for i in range(3):
+            t = fixture.CreateSheepdogDisk(1024**3)
+            p = i + 7000
+            z = i + 1
+            fixture.StartSheep(t[1], port=p, zone=z)
+            self._disks.append(t)
+        time.sleep(2)
+        fixture.ForceFormatCluster(2)
+
+    def tearDown(self):
+        fixture.ShutdownCluster()
+        time.sleep(2)
+        for t in self._disks:
+            fixture.DestroySheepdogDisk(t[0], t[1])
+
+    def testCreateAndDeleteVDI(self):
+        self.assertEquals(0, len(fixture.ListVDI()))
+        self.assertTrue(fixture.CreateVDI("alpha", 128 * (1024**2)))
+        self.assertTrue(fixture.CreateVDI("bravo", 192 * (1024**2)))
+        vdis = fixture.ListVDI()
+        self.assertEquals(2, len(vdis))
+        alpha = filter(lambda x: x["name"] == "alpha", vdis)
+        self.assertEquals(1, len(alpha))
+        self.assertEquals(128 * (1024**2), alpha[0]["nb_size"])
+        bravo = filter(lambda x: x["name"] == "bravo", vdis)
+        self.assertEquals(1, len(bravo))
+        self.assertEquals(192 * (1024**2), bravo[0]["nb_size"])
+        self.assertTrue(fixture.DeleteVDI("alpha"))
+        self.assertEquals(1, len(fixture.ListVDI()))
+        self.assertTrue(fixture.DeleteVDI("bravo"))
+        self.assertEquals(0, len(fixture.ListVDI()))
+
+    def testWriteAndReadVDI(self):
+        self.assertTrue(fixture.CreateVDI("alpha", 4 * (1024**2)))
+        alpha = filter(lambda x: x["name"] == "alpha", fixture.ListVDI())
+        self.assertEquals(1, len(alpha))
+        alpha = alpha[0]
+        self.assertEquals(4 * (1024**2), alpha["nb_size"])
+
+        contentToWrite = os.urandom(4 * (1024**2))
+        self.assertEquals(4 * (1024**2), len(contentToWrite))
+        self.assertTrue(fixture.WriteVDI("alpha", contentToWrite))
+
+        contentRead = fixture.ReadVDI("alpha")
+        self.assertEquals(4 * (1024**2), len(contentRead))
+
+        expected = hashlib.md5(contentToWrite).digest()
+        actual = hashlib.md5(contentRead).digest()
+        self.assertEquals(expected, actual)
+
+    def testSnapshotVDI(self):
+        self.assertTrue(fixture.CreateVDI("alpha", 4 * (1024**2)))
+        alpha = filter(lambda x: x["name"] == "alpha", fixture.ListVDI())
+        self.assertEquals(1, len(alpha))
+        alpha = alpha[0]
+        self.assertEquals(4 * (1024**2), alpha["nb_size"])
+
+        contentToWrite = os.urandom(4 * (1024**2))
+        self.assertEquals(4 * (1024**2), len(contentToWrite))
+        self.assertTrue(fixture.WriteVDI("alpha", contentToWrite))
+
+        self.assertTrue(fixture.SnapshotVDI("alpha", "alpha_1"))
+        pred = lambda x: x["snapshot"] and \
+            x["name"] == "alpha" and \
+            x["tag"] == "alpha_1"
+        self.assertEquals(1, len(filter(pred, fixture.ListVDI())))
+
+        self.assertTrue(fixture.WriteVDI("alpha", os.urandom(4 * (1024**2))))
+
+        contentRead = fixture.ReadVDI("alpha", "alpha_1")
+        self.assertEquals(4 * (1024**2), len(contentRead))
+
+        expected = hashlib.md5(contentToWrite).digest()
+        actual = hashlib.md5(contentRead).digest()
+        self.assertEquals(expected, actual)
+
+        self.assertTrue(fixture.DeleteVDI("alpha", "alpha_1"))
+
+    def testCloneVDI(self):
+        self.assertTrue(fixture.CreateVDI("alpha", 4 * (1024**2)))
+        alpha = filter(lambda x: x["name"] == "alpha", fixture.ListVDI())
+        self.assertEquals(1, len(alpha))
+        alpha = alpha[0]
+        self.assertEquals(4 * (1024**2), alpha["nb_size"])
+
+        contentToWrite = os.urandom(4 * (1024**2))
+        self.assertEquals(4 * (1024**2), len(contentToWrite))
+        self.assertTrue(fixture.WriteVDI("alpha", contentToWrite))
+
+        self.assertTrue(fixture.SnapshotVDI("alpha", "alpha_1"))
+        self.assertTrue(fixture.CloneVDI("alpha", "alpha_1", "bravo"))
+        pred = lambda x: x["cloned"] and x["name"] == "bravo"
+        self.assertEquals(1, len(filter(pred, fixture.ListVDI())))
+
+        self.assertTrue(fixture.WriteVDI("alpha", os.urandom(4 * (1024**2))))
+
+        contentRead = fixture.ReadVDI("bravo")
+        self.assertEquals(4 * (1024**2), len(contentRead))
+
+        expected = hashlib.md5(contentToWrite).digest()
+        actual = hashlib.md5(contentRead).digest()
+        self.assertEquals(expected, actual)
+
+        self.assertTrue(fixture.DeleteVDI("alpha", "alpha_1"))
+        self.assertTrue(fixture.DeleteVDI("alpha"))
+        self.assertTrue(fixture.WriteVDI("bravo", os.urandom(4 * (1024**2))))
+        self.assertTrue(fixture.DeleteVDI("bravo"))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Sheepdog RPCs i.e. `SD_OP_*` cannot be tested easily with existing testing ways. Writing such tests as unit tests in C is boring. Functional tests are not so fine-grained as to make such tests.

This introduces "operation test" in tests/operation to test RPCs. It is written in Python, and contains two main modules:

 1. sheep.py: providing Sheepdog RPCs

    A basic RPC way like as executing `*_exec_req` is implemented. Wrapper methods are also implemented for some RPCs to handle their return values like as C struct.

 2. fixture.py: providing testing fixtures

    We can start sheep processes with temporary disks and run some dog commands with this.

Now we can make RPC tests using these modules and PyUnit framework, easier-to-write than unit test and finer-grained than functional test.

I think this is useful to test patches related to RPCs, such as pull request #168.
