### PR TITLE
lib: A sparse file can be created with atomic_create_and_write()

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -23,7 +23,7 @@ int rmdir_r(const char *dir_path);
 int purge_directory(const char *dir_path);
 int purge_directory_async(const char *dir_path);
 int atomic_create_and_write(const char *path, const char *buf, size_t len,
-                            bool force_create);
+                            bool force_create, bool sparse);
 int install_sighandler(int signum, void (*handler)(int, siginfo_t *, void *),
                        bool once);
 int install_crash_handler(void (*handler)(int, siginfo_t *, void *));

--- a/lib/common.c
+++ b/lib/common.c
@@ -34,7 +34,7 @@ void register_util_wq(struct work_queue *wq)
  * temporary file exists.
  */
 int atomic_create_and_write(const char *path, const char *buf, size_t len,
-			    bool force_create)
+			    bool force_create, bool sparse)
 {
 	int fd, ret;
 	char tmp_path[PATH_MAX];

--- a/sheep/config.c
+++ b/sheep/config.c
@@ -22,7 +22,7 @@ static int write_config(void)
 	int ret;
 
 	ret = atomic_create_and_write(config_path, (char *)&config,
-				      sizeof(config), true);
+				      sizeof(config), true, false);
 	if (ret < 0) {
 		sd_err("atomic_create_and_write() failed");
 		return SD_RES_EIO;

--- a/sheep/store/common.c
+++ b/sheep/store/common.c
@@ -134,7 +134,7 @@ int update_epoch_log(uint32_t epoch, struct sd_node *nodes, size_t nr_nodes)
 
 	snprintf(path, sizeof(path), "%s%08u", epoch_path, epoch);
 
-	ret = atomic_create_and_write(path, buf, len, true);
+	ret = atomic_create_and_write(path, buf, len, true, false);
 
 	free(buf);
 	return ret;

--- a/sheep/store/md.c
+++ b/sheep/store/md.c
@@ -665,7 +665,7 @@ static int md_move_object(uint64_t oid, const char *old, const char *new)
 		goto out_close;
 	}
 
-	if (atomic_create_and_write(new, buf.buf, buf.len, false) < 0) {
+	if (atomic_create_and_write(new, buf.buf, buf.len, false, true) < 0) {
 		if (errno != EEXIST) {
 			sd_err("failed to create %s", new);
 			ret = -1;

--- a/tests/unit/lib/Makefile.am
+++ b/tests/unit/lib/Makefile.am
@@ -1,6 +1,7 @@
 MAINTAINERCLEANFILES	= Makefile.in
 
-TESTS			= test_util test_work
+TESTS			= test_util test_work test_punchhole		\
+			  test_atomic_create_and_write
 
 check_PROGRAMS		= ${TESTS}
 
@@ -22,6 +23,17 @@ test_util_SOURCES	= test_util.c ../../../lib/util.c		\
 
 test_work_SOURCES	= test_work.c ../../../lib/work.c		\
 			  ../unity/src/unity.c
+
+test_punchhole_SOURCES	= test_punchhole.c				\
+			  ../../../lib/util.c				\
+			  ../mocks/Mocklogger.c				\
+			  ../cmock/src/cmock.c ../unity/src/unity.c
+
+test_atomic_create_and_write_SOURCES =					\
+			  test_atomic_create_and_write.c		\
+			  ../../../lib/common.c				\
+			  ../mocks/Mocklogger.c				\
+			  ../cmock/src/cmock.c ../unity/src/unity.c
 
 clean-local:
 	rm -f ${check_PROGRAMS} *.o

--- a/tests/unit/lib/test_atomic_create_and_write.c
+++ b/tests/unit/lib/test_atomic_create_and_write.c
@@ -1,0 +1,134 @@
+#include <fcntl.h>	/* open */
+#include <stdbool.h>
+#include <stdio.h>	/* tmpnam */
+#include <string.h>	/* memset */
+#include <sys/stat.h>	/* stat */
+#include <unistd.h>	/* access */
+
+#include <unity.h>
+#include <cmock.h>
+
+#include "Mocklogger.h"
+#include "util.h"
+#include "common.h"
+
+int sd_log_level = SDOG_INFO;
+
+#define BUF_LEN (BLOCK_SIZE / 2 * 7)
+static char buf[BUF_LEN];
+static char obj_path[L_tmpnam];
+static char tmp_path[L_tmpnam + 4];
+static int tmp_fd;
+
+void setUp(void)
+{
+	memset(buf, 0, BUF_LEN);
+	buf[BLOCK_SIZE] = 1;
+	buf[BLOCK_SIZE * 2 - 1] = 1;
+
+	strcpy(obj_path, "");
+	strcpy(tmp_path, "");
+	tmp_fd = -1;
+
+	if(!tmpnam(obj_path))
+		return;
+
+	sprintf(tmp_path, "%s.tmp", obj_path);
+}
+
+void tearDown(void)
+{
+	if(strlen(obj_path) > 0)
+		unlink(obj_path);
+
+	if(strlen(tmp_path) > 0)
+		unlink(tmp_path);
+
+	if(tmp_fd != -1)
+		close(tmp_fd);
+}
+
+static void subtest_try_unlink(const char *pathname)
+{
+	TEST_ASSERT_TRUE(strlen(pathname) > 0);
+
+	const int r = unlink(pathname);
+	const int e = errno;
+	TEST_ASSERT_TRUE(r == 0 || e == ENOENT);
+}
+
+static int subtest_open(const char *pathname, int flags, mode_t mode)
+{
+	TEST_ASSERT_TRUE(strlen(pathname) > 0);
+
+	const int fd = open(pathname, flags, mode);
+	TEST_ASSERT_FALSE(fd < 0);
+	return fd;
+}
+
+static void subtest_object_content(void)
+{
+	const int fd = subtest_open(obj_path, O_RDONLY, 0);
+
+	char buf_actual[BUF_LEN] = {0};
+	TEST_ASSERT_EQUAL(BUF_LEN, read(fd, buf_actual, BUF_LEN));
+	TEST_ASSERT_EQUAL_INT(0, memcmp(buf, buf_actual, BUF_LEN));
+
+	TEST_ASSERT_EQUAL_INT(0, close(fd));
+}
+
+static void test_atomic_create_and_write_nonexist(void)
+{
+	subtest_try_unlink(tmp_path);
+
+	TEST_ASSERT_EQUAL_INT(0, atomic_create_and_write(obj_path, buf, BUF_LEN, false));
+	TEST_ASSERT_EQUAL_INT(0, access(obj_path, F_OK));
+	TEST_ASSERT_EQUAL_INT(-1, access(tmp_path, F_OK));
+
+	struct stat s;
+	TEST_ASSERT_EQUAL_INT(0, stat(obj_path, &s));
+	TEST_ASSERT_EQUAL(BUF_LEN, s.st_size);
+	TEST_ASSERT_TRUE(BLOCK_SIZE <= s.st_blocks * 512);
+	TEST_ASSERT_TRUE(s.st_size <= s.st_blocks * 512);
+	TEST_ASSERT_TRUE(s.st_size >= s.st_blocks * 512 - BLOCK_SIZE);
+
+	subtest_object_content();
+}
+
+static void test_atomic_create_and_write_nonforce(void)
+{
+	subtest_try_unlink(tmp_path);
+
+	tmp_fd = subtest_open(tmp_path, O_WRONLY | O_CREAT | O_SYNC | O_EXCL, S_IRWXU);
+	TEST_ASSERT_EQUAL_INT(-1, atomic_create_and_write(obj_path, buf, BUF_LEN, false));
+	TEST_ASSERT_EQUAL_INT(-1, access(obj_path, F_OK));
+	TEST_ASSERT_EQUAL_INT(0, access(tmp_path, F_OK));
+}
+
+static void test_atomic_create_and_write_force(void)
+{
+	subtest_try_unlink(tmp_path);
+
+	tmp_fd = subtest_open(tmp_path, O_WRONLY | O_CREAT | O_SYNC | O_EXCL, S_IRWXU);
+	TEST_ASSERT_EQUAL_INT(0, atomic_create_and_write(obj_path, buf, BUF_LEN, true));
+	TEST_ASSERT_EQUAL_INT(0, access(obj_path, F_OK));
+	TEST_ASSERT_EQUAL_INT(-1, access(tmp_path, F_OK));
+
+	struct stat s;
+	TEST_ASSERT_EQUAL_INT(0, stat(obj_path, &s));
+	TEST_ASSERT_EQUAL(BUF_LEN, s.st_size);
+	TEST_ASSERT_TRUE(BLOCK_SIZE <= s.st_blocks * 512);
+	TEST_ASSERT_TRUE(s.st_size <= s.st_blocks * 512);
+	TEST_ASSERT_TRUE(s.st_size >= s.st_blocks * 512 - BLOCK_SIZE);
+
+	subtest_object_content();
+}
+
+int main(int argc, char **argv)
+{
+	UNITY_BEGIN();
+	RUN_TEST(test_atomic_create_and_write_nonexist);
+	RUN_TEST(test_atomic_create_and_write_nonforce);
+	RUN_TEST(test_atomic_create_and_write_force);
+	return UNITY_END();
+}

--- a/tests/unit/lib/test_atomic_create_and_write.c
+++ b/tests/unit/lib/test_atomic_create_and_write.c
@@ -135,7 +135,7 @@ static void test_atomic_create_and_write_sparse(void)
 	struct stat s;
 	TEST_ASSERT_EQUAL_INT(0, stat(obj_path, &s));
 	TEST_ASSERT_EQUAL(BUF_LEN, s.st_size);
-	TEST_ASSERT_EQUAL(BLOCK_SIZE, s.st_blocks * 512); /* FAIL */
+	TEST_ASSERT_EQUAL(BLOCK_SIZE, s.st_blocks * 512);
 
 	subtest_object_content();
 }

--- a/tests/unit/lib/test_punchhole.c
+++ b/tests/unit/lib/test_punchhole.c
@@ -1,0 +1,443 @@
+#include <stdbool.h>
+#include <stdlib.h>	/* mkostemp */
+#include <sys/stat.h>	/* stat */
+#include <fcntl.h>	/* O_* flags */
+#include <unity.h>
+#include <cmock.h>
+
+#include "util.h"
+#include "Mocklogger.h"
+
+static void test_block_size_equals_4K(void)
+{
+	TEST_ASSERT_EQUAL(4096, BLOCK_SIZE);
+}
+
+static void test_find_zero_blocks_null(void)
+{
+	uint64_t offset = 0;
+	uint32_t len = 0;
+	find_zero_blocks(NULL, &offset, &len);
+	TEST_ASSERT_EQUAL_UINT64(0, offset);
+	TEST_ASSERT_EQUAL_UINT32(0, len);
+}
+
+static void test_find_zero_blocks_1(void)
+{
+	const uint8_t buf[1] = {0};
+	uint64_t offset = 0;
+	uint32_t len = 1;
+	find_zero_blocks(buf, &offset, &len);
+	TEST_ASSERT_EQUAL_UINT64(0, offset);
+	TEST_ASSERT_EQUAL_UINT32(1, len);
+}
+
+static void test_find_zero_blocks_4095(void)
+{
+	const uint8_t buf[4095] = {0};
+	uint64_t offset = 0;
+	uint32_t len = 4095;
+	find_zero_blocks(buf, &offset, &len);
+	TEST_ASSERT_EQUAL_UINT64(0, offset);
+	TEST_ASSERT_EQUAL_UINT32(4095, len);
+}
+
+static void test_find_zero_blocks_4K_zero(void)
+{
+	const uint8_t buf[BLOCK_SIZE] = {0};
+	uint64_t offset = 0;
+	uint32_t len = BLOCK_SIZE;
+	find_zero_blocks(buf, &offset, &len);
+	TEST_ASSERT_EQUAL_UINT64(BLOCK_SIZE, offset);
+	TEST_ASSERT_EQUAL_UINT32(0, len);
+}
+
+static void test_find_zero_blocks_4K_nonzero_at_head(void)
+{
+	uint8_t buf[BLOCK_SIZE] = {0};
+		buf[0] = 1;
+	uint64_t offset = 0;
+	uint32_t len = BLOCK_SIZE;
+	find_zero_blocks(buf, &offset, &len);
+	TEST_ASSERT_EQUAL_UINT64(0, offset);
+	TEST_ASSERT_EQUAL_UINT32(BLOCK_SIZE, len);
+}
+
+static void test_find_zero_blocks_4K_nonzero_at_tail(void)
+{
+	uint8_t buf[BLOCK_SIZE] = {0};
+		buf[BLOCK_SIZE - 1] = 1;
+	uint64_t offset = 0;
+	uint32_t len = BLOCK_SIZE;
+	find_zero_blocks(buf, &offset, &len);
+	TEST_ASSERT_EQUAL_UINT64(0, offset);
+	TEST_ASSERT_EQUAL_UINT32(BLOCK_SIZE, len);
+}
+
+static void test_find_zero_blocks_4K_nonzero_at_middle(void)
+{
+	uint8_t buf[BLOCK_SIZE] = {0};
+		buf[BLOCK_SIZE / 2] = 1;
+	uint64_t offset = 0;
+	uint32_t len = BLOCK_SIZE;
+	find_zero_blocks(buf, &offset, &len);
+	TEST_ASSERT_EQUAL_UINT64(0, offset);
+	TEST_ASSERT_EQUAL_UINT32(BLOCK_SIZE, len);
+}
+
+static void test_find_zero_blocks_4097_zero_offset_0(void)
+{
+	const uint8_t buf[BLOCK_SIZE + 1] = {0};
+	uint64_t offset = 0;
+	uint32_t len = BLOCK_SIZE + 1;
+	find_zero_blocks(buf, &offset, &len);
+	TEST_ASSERT_EQUAL_UINT64(BLOCK_SIZE, offset);
+	TEST_ASSERT_EQUAL_UINT32(1, len);
+}
+
+static void test_find_zero_blocks_4097_zero_offset_1(void)
+{
+	const uint8_t buf[BLOCK_SIZE + 1] = {0};
+	uint64_t offset = 1;
+	uint32_t len = BLOCK_SIZE;
+	find_zero_blocks(buf, &offset, &len);
+	TEST_ASSERT_EQUAL_UINT64(BLOCK_SIZE, offset);
+	TEST_ASSERT_EQUAL_UINT32(1, len);
+}
+
+static void test_find_zero_blocks_4097_zero_offset_2(void)
+{
+	const uint8_t buf[BLOCK_SIZE + 1] = {0};
+	uint64_t offset = 2;
+	uint32_t len = BLOCK_SIZE - 1;
+	find_zero_blocks(buf, &offset, &len);
+	TEST_ASSERT_EQUAL_UINT64(2, offset);
+	TEST_ASSERT_EQUAL_UINT32(BLOCK_SIZE - 1, len);
+}
+
+static void test_find_zero_blocks_4097_nonzero_at_0(void)
+{
+	uint8_t buf[BLOCK_SIZE + 1] = {0};
+		buf[0] = 1;
+	uint64_t offset = 0;
+	uint32_t len = BLOCK_SIZE + 1;
+	find_zero_blocks(buf, &offset, &len);
+	TEST_ASSERT_EQUAL_UINT64(0, offset);
+	TEST_ASSERT_EQUAL_UINT32(BLOCK_SIZE, len);
+}
+
+static void test_find_zero_blocks_4097_nonzero_at_4096(void)
+{
+	uint8_t buf[BLOCK_SIZE + 1] = {0};
+		buf[BLOCK_SIZE] = 1;
+	uint64_t offset = 0;
+	uint32_t len = BLOCK_SIZE + 1;
+	find_zero_blocks(buf, &offset, &len);
+	TEST_ASSERT_EQUAL_UINT64(BLOCK_SIZE, offset);
+	TEST_ASSERT_EQUAL_UINT32(1, len);
+}
+
+static void test_find_zero_blocks_8K_zero_zero(void)
+{
+	const uint8_t buf[BLOCK_SIZE * 2] = {0};
+	uint64_t offset = 0;
+	uint32_t len = BLOCK_SIZE * 2;
+	find_zero_blocks(buf, &offset, &len);
+	TEST_ASSERT_EQUAL_UINT64(BLOCK_SIZE * 2, offset);
+	TEST_ASSERT_EQUAL_UINT32(0, len);
+}
+
+static void test_find_zero_blocks_8K_zero_head(void)
+{
+	uint8_t buf[BLOCK_SIZE * 2] = {0};
+		buf[BLOCK_SIZE] = 1;
+	uint64_t offset = 0;
+	uint32_t len = BLOCK_SIZE * 2;
+	find_zero_blocks(buf, &offset, &len);
+	TEST_ASSERT_EQUAL_UINT64(BLOCK_SIZE, offset);
+	TEST_ASSERT_EQUAL_UINT32(BLOCK_SIZE, len);
+}
+
+static void test_find_zero_blocks_8K_zero_tail(void)
+{
+	uint8_t buf[BLOCK_SIZE * 2] = {0};
+		buf[BLOCK_SIZE * 2 - 1] = 1;
+	uint64_t offset = 0;
+	uint32_t len = BLOCK_SIZE * 2;
+	find_zero_blocks(buf, &offset, &len);
+	TEST_ASSERT_EQUAL_UINT64(BLOCK_SIZE, offset);
+	TEST_ASSERT_EQUAL_UINT32(BLOCK_SIZE, len);
+}
+
+static void test_find_zero_blocks_8K_head_zero(void)
+{
+	uint8_t buf[BLOCK_SIZE * 2] = {0};
+		buf[0] = 1;
+	uint64_t offset = 0;
+	uint32_t len = BLOCK_SIZE * 2;
+	find_zero_blocks(buf, &offset, &len);
+	TEST_ASSERT_EQUAL_UINT64(0, offset);
+	TEST_ASSERT_EQUAL_UINT32(BLOCK_SIZE, len);
+}
+
+static void test_find_zero_blocks_8K_tail_zero(void)
+{
+	uint8_t buf[BLOCK_SIZE * 2] = {0};
+		buf[BLOCK_SIZE - 1] = 1;
+	uint64_t offset = 0;
+	uint32_t len = BLOCK_SIZE * 2;
+	find_zero_blocks(buf, &offset, &len);
+	TEST_ASSERT_EQUAL_UINT64(0, offset);
+	TEST_ASSERT_EQUAL_UINT32(BLOCK_SIZE, len);
+}
+
+static void test_find_zero_blocks_8K_head_tail(void)
+{
+	uint8_t buf[BLOCK_SIZE * 2] = {0};
+		buf[0] = 1;
+		buf[BLOCK_SIZE * 2 - 1] = 1;
+	uint64_t offset = 0;
+	uint32_t len = BLOCK_SIZE * 2;
+	find_zero_blocks(buf, &offset, &len);
+	TEST_ASSERT_EQUAL_UINT64(0, offset);
+	TEST_ASSERT_EQUAL_UINT32(BLOCK_SIZE * 2, len);
+}
+
+static void test_find_zero_blocks_8K_tail_head(void)
+{
+	uint8_t buf[BLOCK_SIZE * 2] = {0};
+		buf[BLOCK_SIZE - 1] = 1;
+		buf[BLOCK_SIZE] = 1;
+	uint64_t offset = 0;
+	uint32_t len = BLOCK_SIZE * 2;
+	find_zero_blocks(buf, &offset, &len);
+	TEST_ASSERT_EQUAL_UINT64(0, offset);
+	TEST_ASSERT_EQUAL_UINT32(BLOCK_SIZE * 2, len);
+}
+
+static void test_find_zero_blocks_12K_zero_zero_tail(void)
+{
+	uint8_t buf[BLOCK_SIZE * 3] = {0};
+		buf[BLOCK_SIZE * 3 - 1] = 1;
+	uint64_t offset = 0;
+	uint32_t len = BLOCK_SIZE * 3;
+	find_zero_blocks(buf, &offset, &len);
+	TEST_ASSERT_EQUAL_UINT64(BLOCK_SIZE * 2, offset);
+	TEST_ASSERT_EQUAL_UINT32(BLOCK_SIZE, len);
+}
+
+static void test_find_zero_blocks_12K_head_zero_zero(void)
+{
+	uint8_t buf[BLOCK_SIZE * 3] = {0};
+		buf[0] = 1;
+	uint64_t offset = 0;
+	uint32_t len = BLOCK_SIZE * 3;
+	find_zero_blocks(buf, &offset, &len);
+	TEST_ASSERT_EQUAL_UINT64(0, offset);
+	TEST_ASSERT_EQUAL_UINT32(BLOCK_SIZE, len);
+}
+
+static void test_find_zero_blocks_12K_zero_middle_zero(void)
+{
+	uint8_t buf[BLOCK_SIZE * 3] = {0};
+		buf[BLOCK_SIZE + BLOCK_SIZE / 2] = 1;
+	uint64_t offset = 0;
+	uint32_t len = BLOCK_SIZE * 3;
+	find_zero_blocks(buf, &offset, &len);
+	TEST_ASSERT_EQUAL_UINT64(BLOCK_SIZE, offset);
+	TEST_ASSERT_EQUAL_UINT32(BLOCK_SIZE, len);
+}
+
+static void test_find_zero_blocks_12K_head_zero_tail(void)
+{
+	uint8_t buf[BLOCK_SIZE * 3] = {0};
+		buf[0] = 1;
+		buf[BLOCK_SIZE * 3 - 1] = 1;
+	uint64_t offset = 0;
+	uint32_t len = BLOCK_SIZE * 3;
+	find_zero_blocks(buf, &offset, &len);
+	TEST_ASSERT_EQUAL_UINT64(0, offset);
+	TEST_ASSERT_EQUAL_UINT32(BLOCK_SIZE * 3, len);
+}
+
+static void test_find_zero_blocks_20K_zero_zero_middle_zero_zero(void)
+{
+	uint8_t buf[BLOCK_SIZE * 5] = {0};
+		buf[BLOCK_SIZE * 5 / 2] = 1;
+	uint64_t offset = 0;
+	uint32_t len = BLOCK_SIZE * 5;
+	find_zero_blocks(buf, &offset, &len);
+	TEST_ASSERT_EQUAL_UINT64(BLOCK_SIZE * 2, offset);
+	TEST_ASSERT_EQUAL_UINT32(BLOCK_SIZE, len);
+}
+
+static int subtest_make_temporary_file(void)
+{
+	const static int flags = O_WRONLY | O_CREAT | O_SYNC | O_EXCL;
+
+	char template[] = "/tmp/test_util.XXXXXX";
+	const int fd = mkostemp(template, flags);
+	TEST_ASSERT_TRUE(fd != -1);
+
+	/* Deleting temporary file when close */
+	TEST_ASSERT_EQUAL_INT(0, unlink(template));
+
+	return fd;
+}
+
+static bool subtest_try_discard_head(int fd, uint64_t head)
+{
+	const static int mode = FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE;
+
+	TEST_ASSERT_EQUAL(0, head % BLOCK_SIZE);
+
+	if (head > 0) {
+		TEST_ASSERT_EQUAL_INT(0, xfallocate(fd, mode, 0, head));
+		return true;
+	}
+
+	return false;
+}
+
+static bool subtest_try_discard_tail(int fd, uint64_t head, uint32_t len,
+				     size_t end)
+{
+	const static int mode = FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE;
+
+	TEST_ASSERT_EQUAL(0, head % BLOCK_SIZE);
+
+	const size_t tail = head + len;
+	if (tail < end) {
+		TEST_ASSERT_EQUAL(0, len % BLOCK_SIZE);
+
+		const size_t block_end = roundup(end, BLOCK_SIZE);
+		TEST_ASSERT_EQUAL_INT(0, block_end % BLOCK_SIZE);
+		TEST_ASSERT_TRUE(end <= block_end);
+		TEST_ASSERT_TRUE(end >= block_end - BLOCK_SIZE);
+		TEST_ASSERT_EQUAL_INT(0, xfallocate(fd, mode, tail,
+						    block_end - tail));
+		return true;
+	}
+
+	return false;
+}
+
+static void test_make_sparse_file(void)
+{
+	const static size_t BUF_LEN = BLOCK_SIZE / 2 * 7;
+	uint8_t buf[BLOCK_SIZE / 2 * 7] = {0};
+                buf[BLOCK_SIZE] = 1;
+	        buf[BLOCK_SIZE * 2 - 1] = 1;
+
+	const int fd = subtest_make_temporary_file();
+
+	struct stat s;
+
+	TEST_ASSERT_EQUAL_INT(0, fstat(fd, &s));
+	TEST_ASSERT_EQUAL(0, s.st_size);
+	TEST_ASSERT_EQUAL(0, s.st_blocks);
+
+	TEST_ASSERT_EQUAL(BUF_LEN, xwrite(fd, buf, BUF_LEN));
+
+	TEST_ASSERT_EQUAL_INT(0, fstat(fd, &s));
+	TEST_ASSERT_EQUAL(BUF_LEN, s.st_size);
+	TEST_ASSERT_TRUE(BLOCK_SIZE <= s.st_blocks * 512);
+	TEST_ASSERT_TRUE(s.st_size <= s.st_blocks * 512);
+	TEST_ASSERT_TRUE(s.st_size >= s.st_blocks * 512 - BLOCK_SIZE);
+
+	uint64_t head = 0;
+	uint32_t len = BUF_LEN;
+	find_zero_blocks(buf, &head, &len);
+	TEST_ASSERT_EQUAL_UINT64(BLOCK_SIZE, head);
+	TEST_ASSERT_EQUAL_UINT32(BLOCK_SIZE, len);
+	TEST_ASSERT_TRUE(subtest_try_discard_head(fd, head));
+	TEST_ASSERT_TRUE(subtest_try_discard_tail(fd, head, len, BUF_LEN));
+
+	TEST_ASSERT_EQUAL_INT(0, fstat(fd, &s));
+	TEST_ASSERT_EQUAL(BUF_LEN, s.st_size);
+	TEST_ASSERT_EQUAL(BLOCK_SIZE, s.st_blocks * 512);
+
+	uint8_t buf_actual[BLOCK_SIZE / 2 * 7] = {0};
+	TEST_ASSERT_EQUAL_INT(0, lseek(fd, 0, SEEK_SET)); /* rewind */
+	TEST_ASSERT_EQUAL(BUF_LEN, read(fd, buf_actual, BUF_LEN));
+	TEST_ASSERT_EQUAL_INT(0, memcmp(buf, buf_actual, BUF_LEN));
+
+	TEST_ASSERT_EQUAL(0, close(fd));
+}
+
+static void test_make_nonsparse_file(void)
+{
+	const static size_t BUF_LEN = BLOCK_SIZE / 2 * 7;
+	uint8_t buf[BLOCK_SIZE / 2 * 7];
+	memset(buf, 1, BUF_LEN);
+
+	const int fd = subtest_make_temporary_file();
+
+	struct stat s;
+
+	TEST_ASSERT_EQUAL_INT(0, fstat(fd, &s));
+	TEST_ASSERT_EQUAL(0, s.st_size);
+	TEST_ASSERT_EQUAL(0, s.st_blocks);
+
+	TEST_ASSERT_EQUAL(BUF_LEN, xwrite(fd, buf, BUF_LEN));
+
+	TEST_ASSERT_EQUAL_INT(0, fstat(fd, &s));
+	TEST_ASSERT_EQUAL(BUF_LEN, s.st_size);
+	TEST_ASSERT_TRUE(BLOCK_SIZE <= s.st_blocks * 512);
+	TEST_ASSERT_TRUE(s.st_size <= s.st_blocks * 512);
+	TEST_ASSERT_TRUE(s.st_size >= s.st_blocks * 512 - BLOCK_SIZE);
+
+	uint64_t head = 0;
+	uint32_t len = BUF_LEN;
+	find_zero_blocks(buf, &head, &len);
+	TEST_ASSERT_EQUAL_UINT64(0, head);
+	TEST_ASSERT_EQUAL_UINT32(BUF_LEN, len);
+	TEST_ASSERT_FALSE(subtest_try_discard_head(fd, head));
+	TEST_ASSERT_FALSE(subtest_try_discard_tail(fd, head, len, BUF_LEN));
+
+	TEST_ASSERT_EQUAL_INT(0, fstat(fd, &s));
+	TEST_ASSERT_EQUAL(BUF_LEN, s.st_size);
+	TEST_ASSERT_TRUE(BLOCK_SIZE <= s.st_blocks * 512);
+	TEST_ASSERT_TRUE(s.st_size <= s.st_blocks * 512);
+	TEST_ASSERT_TRUE(s.st_size >= s.st_blocks * 512 - BLOCK_SIZE);
+
+	uint8_t buf_actual[BLOCK_SIZE / 2 * 7] = {0};
+	TEST_ASSERT_EQUAL_INT(0, lseek(fd, 0, SEEK_SET)); /* rewind */
+	TEST_ASSERT_EQUAL(BUF_LEN, read(fd, buf_actual, BUF_LEN));
+	TEST_ASSERT_EQUAL_INT(0, memcmp(buf, buf_actual, BUF_LEN));
+
+	TEST_ASSERT_EQUAL(0, close(fd));
+}
+
+int main(int argc, char **argv)
+{
+	UNITY_BEGIN();
+	RUN_TEST(test_block_size_equals_4K);
+	RUN_TEST(test_find_zero_blocks_null);
+	RUN_TEST(test_find_zero_blocks_1);
+	RUN_TEST(test_find_zero_blocks_4095);
+	RUN_TEST(test_find_zero_blocks_4K_zero);
+	RUN_TEST(test_find_zero_blocks_4K_nonzero_at_head);
+	RUN_TEST(test_find_zero_blocks_4K_nonzero_at_tail);
+	RUN_TEST(test_find_zero_blocks_4K_nonzero_at_middle);
+	RUN_TEST(test_find_zero_blocks_4097_zero_offset_0);
+	RUN_TEST(test_find_zero_blocks_4097_zero_offset_1);
+	RUN_TEST(test_find_zero_blocks_4097_zero_offset_2);
+	RUN_TEST(test_find_zero_blocks_4097_nonzero_at_0);
+	RUN_TEST(test_find_zero_blocks_4097_nonzero_at_4096);
+	RUN_TEST(test_find_zero_blocks_8K_zero_zero);
+	RUN_TEST(test_find_zero_blocks_8K_zero_head);
+	RUN_TEST(test_find_zero_blocks_8K_zero_tail);
+	RUN_TEST(test_find_zero_blocks_8K_head_zero);
+	RUN_TEST(test_find_zero_blocks_8K_tail_zero);
+	RUN_TEST(test_find_zero_blocks_8K_head_tail);
+	RUN_TEST(test_find_zero_blocks_8K_tail_head);
+	RUN_TEST(test_find_zero_blocks_12K_zero_zero_tail);
+	RUN_TEST(test_find_zero_blocks_12K_head_zero_zero);
+	RUN_TEST(test_find_zero_blocks_12K_zero_middle_zero);
+	RUN_TEST(test_find_zero_blocks_12K_head_zero_tail);
+	RUN_TEST(test_find_zero_blocks_20K_zero_zero_middle_zero_zero);
+	RUN_TEST(test_make_sparse_file);
+	RUN_TEST(test_make_nonsparse_file);
+	return UNITY_END();
+}


### PR DESCRIPTION
This adds a parameter 'sparse' to atomic_create_and_write(). If sparse is true, atomic_create_and_write() should create sparse file. Otherwise, it should do like as before i.e. create non-sparse file.

This also makes md_move_object() in sheep/store/md.c call atomic_create_and_write() with sparse=true. Hereby, object files will be sparsed when they move between disks.

Fixes #227.

Signed-off-by: Takashi Menjo &lt;menjo.takashi@lab.ntt.co.jp&gt;