### PR TITLE
dog: Remove object cache feature

### DIFF
--- a/dog/vdi.c
+++ b/dog/vdi.c
@@ -2613,16 +2613,6 @@ static int vdi_object(int argc, char **argv)
 	return do_generic_subcommand(vdi_object_cmd, argc, argv);
 }
 
-
-static struct subcommand vdi_cache_cmd[] = {
-	{NULL,},
-};
-
-static int vdi_cache(int argc, char **argv)
-{
-	return do_generic_subcommand(vdi_cache_cmd, argc, argv);
-}
-
 static void construct_vdi_tree(uint32_t vid, const char *name, const char *tag,
 			       uint32_t snapid, uint32_t flags,
 			       const struct sd_inode *i, void *data)
@@ -2921,10 +2911,6 @@ static struct subcommand vdi_cmd[] = {
 	 "restore snapshot images from a backup provided in STDIN",
 	 NULL, CMD_NEED_ROOT|CMD_NEED_NODELIST|CMD_NEED_ARG,
 	 vdi_restore, vdi_options},
-	{"cache", "<vdiname>", "saphT",
-	 "Run 'dog vdi cache' for more information",
-	 vdi_cache_cmd, CMD_NEED_ROOT|CMD_NEED_ARG,
-	 vdi_cache, vdi_options},
 	{"alter-copy", "<vdiname>", "caphTf", "set the vdi's redundancy level",
 	 NULL, CMD_NEED_ROOT|CMD_NEED_ARG|CMD_NEED_NODELIST, vdi_alter_copy, vdi_options},
 	{"lock", NULL, "aphT", "See 'dog vdi lock' for more information",

--- a/dog/vdi.c
+++ b/dog/vdi.c
@@ -914,16 +914,6 @@ static int do_vdi_delete(const char *vdiname, int snap_id, const char *snap_tag)
 		goto out;
 	}
 
-	sd_init_req(&hdr, SD_OP_DELETE_CACHE);
-	hdr.obj.oid = vid_to_vdi_oid(vid);
-
-	ret = send_light_req(&sd_nid, &hdr);
-	if (ret) {
-		sd_err("failed to execute request");
-		ret = EXIT_FAILURE;
-		goto out;
-	}
-
 	ret = dog_read_object(vid_to_vdi_oid(vid), inode, sizeof(*inode),
 			      0, false);
 	if (ret) {
@@ -2583,43 +2573,6 @@ out:
 	return ret;
 }
 
-static int vdi_cache_delete(int argc, char **argv)
-{
-	const char *vdiname;
-	struct sd_req hdr;
-	uint32_t vid;
-	int ret = EXIT_SUCCESS;
-
-	if (optind < argc)
-		vdiname = argv[optind++];
-	else {
-		sd_err("please specify VDI name");
-		ret = EXIT_FAILURE;
-		goto out;
-	}
-
-	ret = find_vdi_name(vdiname, vdi_cmd_data.snapshot_id,
-			    vdi_cmd_data.snapshot_tag, &vid);
-	if (ret != SD_RES_SUCCESS) {
-		sd_err("Failed to open VDI %s (snapshot id: %d snapshot tag: %s)"
-				": %s", vdiname, vdi_cmd_data.snapshot_id,
-				vdi_cmd_data.snapshot_tag, sd_strerror(ret));
-		ret = EXIT_FAILURE;
-		goto out;
-	}
-
-	sd_init_req(&hdr, SD_OP_DELETE_CACHE);
-	hdr.obj.oid = vid_to_vdi_oid(vid);
-
-	ret = send_light_req(&sd_nid, &hdr);
-	if (ret) {
-		sd_err("failed to execute request");
-		return EXIT_FAILURE;
-	}
-out:
-	return ret;
-}
-
 static int vdi_object_dump_inode(int argc, char **argv)
 {
 	struct sd_inode *inode = xzalloc(sizeof(*inode));
@@ -2701,8 +2654,6 @@ static int vdi_object(int argc, char **argv)
 static struct subcommand vdi_cache_cmd[] = {
 	{"flush", NULL, NULL, "flush the cache of the vdi specified.",
 	 NULL, CMD_NEED_ARG, vdi_cache_flush},
-	{"delete", NULL, NULL, "delete the cache of the vdi specified in all nodes.",
-	 NULL, CMD_NEED_ARG, vdi_cache_delete},
 	{NULL,},
 };
 

--- a/dog/vdi.c
+++ b/dog/vdi.c
@@ -2536,43 +2536,6 @@ out:
 	return ret;
 }
 
-static int vdi_cache_flush(int argc, char **argv)
-{
-	const char *vdiname;
-	struct sd_req hdr;
-	uint32_t vid;
-	int ret = EXIT_SUCCESS;
-
-	if (optind < argc)
-		vdiname = argv[optind++];
-	else {
-		sd_err("please specify VDI name");
-		ret = EXIT_FAILURE;
-		goto out;
-	}
-
-	ret = find_vdi_name(vdiname, vdi_cmd_data.snapshot_id,
-			    vdi_cmd_data.snapshot_tag, &vid);
-	if (ret != SD_RES_SUCCESS) {
-		sd_err("Failed to open VDI %s (snapshot id: %d snapshot tag: %s)"
-				": %s", vdiname, vdi_cmd_data.snapshot_id,
-				vdi_cmd_data.snapshot_tag, sd_strerror(ret));
-		ret = EXIT_FAILURE;
-		goto out;
-	}
-
-	sd_init_req(&hdr, SD_OP_FLUSH_VDI);
-	hdr.obj.oid = vid_to_vdi_oid(vid);
-
-	ret = send_light_req(&sd_nid, &hdr);
-	if (ret) {
-		sd_err("failed to execute request");
-		return EXIT_FAILURE;
-	}
-out:
-	return ret;
-}
-
 static int vdi_object_dump_inode(int argc, char **argv)
 {
 	struct sd_inode *inode = xzalloc(sizeof(*inode));
@@ -2652,8 +2615,6 @@ static int vdi_object(int argc, char **argv)
 
 
 static struct subcommand vdi_cache_cmd[] = {
-	{"flush", NULL, NULL, "flush the cache of the vdi specified.",
-	 NULL, CMD_NEED_ARG, vdi_cache_flush},
 	{NULL,},
 };
 

--- a/include/internal_proto.h
+++ b/include/internal_proto.h
@@ -85,7 +85,7 @@
 #define SD_OP_FLUSH_NODES 0xAD
 #define SD_OP_FLUSH_PEER 0xAE
 #define SD_OP_NOTIFY_VDI_ADD  0xAF
-#define SD_OP_DELETE_CACHE    0xB0
+#define SD_OP_DELETE_CACHE    0xB0 /* obsolete */
 #define SD_OP_MD_INFO   0xB1
 #define SD_OP_MD_PLUG   0xB2
 #define SD_OP_MD_UNPLUG 0xB3

--- a/include/sheepdog_proto.h
+++ b/include/sheepdog_proto.h
@@ -42,7 +42,7 @@
 #define SD_OP_RELEASE_VDI    0x13
 #define SD_OP_GET_VDI_INFO   0x14
 #define SD_OP_READ_VDIS      0x15
-#define SD_OP_FLUSH_VDI      0x16
+#define SD_OP_FLUSH_VDI      0x16 /* obsolete */
 #define SD_OP_DEL_VDI        0x17
 #define SD_OP_GET_CLUSTER_DEFAULT   0x18
 


### PR DESCRIPTION
This is the remaining work related to PR #226. This removes not only SD_OP_DELETE_CACHE but also SD_OP_FLUSH_VDI, so whole the command `dog vdi cache` also be removed.

We might want to close issues #64 and #74.