### PR TITLE
lib: fix the build error on centos

### DIFF
--- a/lib/common.c
+++ b/lib/common.c
@@ -23,6 +23,13 @@
 #include "work.h"
 #include "common.h"
 
+#ifndef FALLOC_FL_KEEP_SIZE
+#define FALLOC_FL_KEEP_SIZE 0x01
+#endif
+#ifndef FALLOC_FL_PUNCH_HOLE
+#define FALLOC_FL_PUNCH_HOLE 0x02
+#endif
+
 static struct work_queue *util_wqueue;
 
 void register_util_wq(struct work_queue *wq)


### PR DESCRIPTION
Met below error on centos

common.c: In function ‘atomic_create_and_write’:
common.c:78:9: error: ‘FALLOC_FL_KEEP_SIZE’ undeclared (first use in this function)
     fd, FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE,
         ^
common.c:78:9: note: each undeclared identifier is reported only once for each function it appears in
common.c:78:31: error: ‘FALLOC_FL_PUNCH_HOLE’ undeclared (first use in this function)
     fd, FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE,
                               ^
make[1]: *** [common.o] Error 1

Signed-off-by: Frank Yu <flyxiaoyu@gmail.com>