### PR TITLE
use the appropriate headers instead of define the macros

### DIFF
--- a/lib/common.c
+++ b/lib/common.c
@@ -18,17 +18,11 @@
 #include <fcntl.h>
 #include <dirent.h>
 #include <inttypes.h>
+#include <linux/falloc.h>
 
 #include "util.h"
 #include "work.h"
 #include "common.h"
-
-#ifndef FALLOC_FL_KEEP_SIZE
-#define FALLOC_FL_KEEP_SIZE 0x01
-#endif
-#ifndef FALLOC_FL_PUNCH_HOLE
-#define FALLOC_FL_PUNCH_HOLE 0x02
-#endif
 
 static struct work_queue *util_wqueue;
 

--- a/sheep/store/common.c
+++ b/sheep/store/common.c
@@ -20,10 +20,6 @@ char *epoch_path;
 struct store_driver *sd_store;
 LIST_HEAD(store_drivers);
 
-#ifndef FALLOC_FL_PUNCH_HOLE
-#define FALLOC_FL_PUNCH_HOLE 0x02
-#endif
-
 #define sector_algined(x) ({ ((x) & (SECTOR_SIZE - 1)) == 0; })
 
 static inline bool iocb_is_aligned(const struct siocb *iocb)

--- a/tests/unit/lib/test_punchhole.c
+++ b/tests/unit/lib/test_punchhole.c
@@ -4,6 +4,7 @@
 #include <fcntl.h>	/* O_* flags */
 #include <unity.h>
 #include <cmock.h>
+#include <linux/falloc.h>
 
 #include "util.h"
 #include "Mocklogger.h"


### PR DESCRIPTION
Signed-off-by: Frank Yu <flyxiaoyu@gmail.com>