### PR TITLE
tests/functional: Fix functional test 081 to be passed

### DIFF
--- a/tests/functional/081
+++ b/tests/functional/081
@@ -8,10 +8,11 @@ _need_to_be_root
 
 which nginx > /dev/null || _notrun "Require nginx but it's not running"
 pkill nginx > /dev/null
+sleep 2
 nginx -c `pwd`/nginx.conf
 
 for i in `seq 0 5`; do
-	_start_sheep $i "-r swift,port=800$i"
+	_start_sheep $i "-r swift,port=800$i,host=127.0.0.1"
 done
 
 _wait_for_sheep 6

--- a/tests/functional/081.out
+++ b/tests/functional/081.out
@@ -3,6 +3,7 @@ using backend plain store
 dog
 sheep
 checker.c
+common.c
 config.c
 corosync.c
 data137
@@ -28,15 +29,19 @@ ops.c
 plain_store.c
 recovery.c
 request.c
+request_tp.c
 s3.c
 sheep.c
 shepherd.c
-store.c
 swift.c
 trace.c
+tree_store.c
 vdi.c
 xdr.c
+xio_client.c
+xio_server.c
 zookeeper.c
+benchmark.c
 cluster.c
 common.c
 dog.c
@@ -50,31 +55,32 @@ snap.c
 trace.c
 treeview.c
 trunk.c
+upgrade.c
 vdi.c
 < HTTP/1.1 416 Requested Range Not Satisfiable
 < HTTP/1.1 416 Requested Range Not Satisfiable
 < HTTP/1.1 416 Requested Range Not Satisfiable
-  Name        Id    Size    Used  Shared    Creation time   VDI id  Copies  Tag
-  sd/dog       0   16 PB   56 MB  0.0 MB DATE   5a5cbf    4:2              
-  sd           0   16 PB  8.0 MB  0.0 MB DATE   7927f2    4:2              
-  sd/sheep     0   16 PB  144 MB  0.0 MB DATE   8ad11e    4:2              
-  sd/dog/allocator     0   16 PB  4.0 MB  0.0 MB DATE   936d95    4:2              
-  sd/sheep/allocator     0   16 PB  268 MB  0.0 MB DATE   fd57fc    4:2              
+  Name        Id    Size    Used  Shared    Creation time   VDI id  Copies  Tag   Block Size Shift
+  sd/dog       0   16 PB   64 MB  0.0 MB DATE   5a5cbf    4:2                22
+  sd           0   16 PB  8.0 MB  0.0 MB DATE   7927f2    4:2                22
+  sd/sheep     0   16 PB  156 MB  0.0 MB DATE   8ad11e    4:2                22
+  sd/dog/allocator     0   16 PB  4.0 MB  0.0 MB DATE   936d95    4:2                22
+  sd/sheep/allocator     0   16 PB  268 MB  0.0 MB DATE   fd57fc    4:2                22
 data137
 data19
 data4
 data97
-  Name        Id    Size    Used  Shared    Creation time   VDI id  Copies  Tag
-  sd/dog       0   16 PB   56 MB  0.0 MB DATE   5a5cbf    4:2              
-  sd           0   16 PB  8.0 MB  0.0 MB DATE   7927f2    4:2              
-  sd/sheep     0   16 PB  144 MB  0.0 MB DATE   8ad11e    4:2              
-  sd/dog/allocator     0   16 PB  4.0 MB  0.0 MB DATE   936d95    4:2              
-  sd/sheep/allocator     0   16 PB  268 MB  0.0 MB DATE   fd57fc    4:2              
+  Name        Id    Size    Used  Shared    Creation time   VDI id  Copies  Tag   Block Size Shift
+  sd/dog       0   16 PB   64 MB  0.0 MB DATE   5a5cbf    4:2                22
+  sd           0   16 PB  8.0 MB  0.0 MB DATE   7927f2    4:2                22
+  sd/sheep     0   16 PB  156 MB  0.0 MB DATE   8ad11e    4:2                22
+  sd/dog/allocator     0   16 PB  4.0 MB  0.0 MB DATE   936d95    4:2                22
+  sd/sheep/allocator     0   16 PB  268 MB  0.0 MB DATE   fd57fc    4:2                22
 dog
 sheep
-  Name        Id    Size    Used  Shared    Creation time   VDI id  Copies  Tag
-  sd/dog       0   16 PB   56 MB  0.0 MB DATE   5a5cbf    4:2              
-  sd           0   16 PB  8.0 MB  0.0 MB DATE   7927f2    4:2              
-  sd/sheep     0   16 PB  144 MB  0.0 MB DATE   8ad11e    4:2              
-  sd/dog/allocator     0   16 PB  4.0 MB  0.0 MB DATE   936d95    4:2              
-  sd/sheep/allocator     0   16 PB  4.0 MB  0.0 MB DATE   fd57fc    4:2              
+  Name        Id    Size    Used  Shared    Creation time   VDI id  Copies  Tag   Block Size Shift
+  sd/dog       0   16 PB   64 MB  0.0 MB DATE   5a5cbf    4:2                22
+  sd           0   16 PB  8.0 MB  0.0 MB DATE   7927f2    4:2                22
+  sd/sheep     0   16 PB  156 MB  0.0 MB DATE   8ad11e    4:2                22
+  sd/dog/allocator     0   16 PB  4.0 MB  0.0 MB DATE   936d95    4:2                22
+  sd/sheep/allocator     0   16 PB  4.0 MB  0.0 MB DATE   fd57fc    4:2                22


### PR DESCRIPTION
The out file of this test is incorrect.

The default value of "-r" option is "host=localhost".
but, sheepdog process is down, if "host=localhost" is passed to the argument of FCGX_OpenSocket function.

Signed-off-by: Yasuhito Fukuda <fukuda.yasuhito@po.ntts.co.jp>
Signed-off-by: Satoshi Kuramochi <act.kura@gmail.com>