### PR TITLE
tests/functional: Fix functional test 084 to be passed

### DIFF
--- a/tests/functional/084
+++ b/tests/functional/084
@@ -8,10 +8,11 @@ _need_to_be_root
 
 which nginx > /dev/null || _notrun "Require nginx but it's not running"
 pkill nginx > /dev/null
+sleep 2
 nginx -c `pwd`/nginx.conf
 
 for i in `seq 0 5`; do
-	_start_sheep $i "-r swift,port=800$i"
+	_start_sheep $i "-r swift,port=800$i,host=127.0.0.1"
 done
 
 _wait_for_sheep 6


### PR DESCRIPTION
The default value of "-r" option is "host=localhost".
but, sheepdog process is down, if "host=localhost" is passed to the argument of FCGX_OpenSocket function.

Signed-off-by: Yasuhito Fukuda <fukuda.yasuhito@po.ntts.co.jp>
Signed-off-by: Satoshi Kuramochi <act.kura@gmail.com>