### PR TITLE
tests/functional: Fix functional test 090 to be passed

### DIFF
--- a/tests/functional/090
+++ b/tests/functional/090
@@ -8,10 +8,11 @@ _need_to_be_root
 
 which nginx > /dev/null || _notrun "Require nginx but it's not running"
 pkill nginx > /dev/null
+sleep 2
 nginx -c `pwd`/nginx.conf
 
 for i in `seq 0 5`; do
-       _start_sheep $i "-r swift,port=800$i"
+       _start_sheep $i "-r swift,port=800$i,host=127.0.0.1"
 done
 
 _wait_for_sheep 6

--- a/tests/functional/090.out
+++ b/tests/functional/090.out
@@ -1,20 +1,20 @@
 QA output created by 090
 using backend plain store
-  Name        Id    Size    Used  Shared    Creation time   VDI id  Copies  Tag
-  sd/dog       0   16 PB  0.0 MB  0.0 MB DATE   5a5cbf    4:2              
-  sd           0   16 PB  8.0 MB  0.0 MB DATE   7927f2    4:2              
-  sd/sheep     0   16 PB  4.0 MB  0.0 MB DATE   8ad11e    4:2              
-  sd/dog/allocator     0   16 PB  4.0 MB  0.0 MB DATE   936d95    4:2              
-  sd/sheep/allocator     0   16 PB   32 MB  0.0 MB DATE   fd57fc    4:2              
-  Name        Id    Size    Used  Shared    Creation time   VDI id  Copies  Tag
-  sd/dog       0   16 PB  0.0 MB  0.0 MB DATE   5a5cbf    4:2              
-  sd           0   16 PB  8.0 MB  0.0 MB DATE   7927f2    4:2              
-  sd/sheep     0   16 PB  8.0 MB  0.0 MB DATE   8ad11e    4:2              
-  sd/dog/allocator     0   16 PB  4.0 MB  0.0 MB DATE   936d95    4:2              
-  sd/sheep/allocator     0   16 PB   44 MB  0.0 MB DATE   fd57fc    4:2              
-  Name        Id    Size    Used  Shared    Creation time   VDI id  Copies  Tag
-  sd/dog       0   16 PB  0.0 MB  0.0 MB DATE   5a5cbf    4:2              
-  sd           0   16 PB  8.0 MB  0.0 MB DATE   7927f2    4:2              
-  sd/sheep     0   16 PB   12 MB  0.0 MB DATE   8ad11e    4:2              
-  sd/dog/allocator     0   16 PB  4.0 MB  0.0 MB DATE   936d95    4:2              
-  sd/sheep/allocator     0   16 PB   92 MB  0.0 MB DATE   fd57fc    4:2              
+  Name        Id    Size    Used  Shared    Creation time   VDI id  Copies  Tag   Block Size Shift
+  sd/dog       0   16 PB  0.0 MB  0.0 MB DATE   5a5cbf    4:2                22
+  sd           0   16 PB  8.0 MB  0.0 MB DATE   7927f2    4:2                22
+  sd/sheep     0   16 PB  4.0 MB  0.0 MB DATE   8ad11e    4:2                22
+  sd/dog/allocator     0   16 PB  4.0 MB  0.0 MB DATE   936d95    4:2                22
+  sd/sheep/allocator     0   16 PB   32 MB  0.0 MB DATE   fd57fc    4:2                22
+  Name        Id    Size    Used  Shared    Creation time   VDI id  Copies  Tag   Block Size Shift
+  sd/dog       0   16 PB  0.0 MB  0.0 MB DATE   5a5cbf    4:2                22
+  sd           0   16 PB  8.0 MB  0.0 MB DATE   7927f2    4:2                22
+  sd/sheep     0   16 PB  8.0 MB  0.0 MB DATE   8ad11e    4:2                22
+  sd/dog/allocator     0   16 PB  4.0 MB  0.0 MB DATE   936d95    4:2                22
+  sd/sheep/allocator     0   16 PB   44 MB  0.0 MB DATE   fd57fc    4:2                22
+  Name        Id    Size    Used  Shared    Creation time   VDI id  Copies  Tag   Block Size Shift
+  sd/dog       0   16 PB  0.0 MB  0.0 MB DATE   5a5cbf    4:2                22
+  sd           0   16 PB  8.0 MB  0.0 MB DATE   7927f2    4:2                22
+  sd/sheep     0   16 PB   12 MB  0.0 MB DATE   8ad11e    4:2                22
+  sd/dog/allocator     0   16 PB  4.0 MB  0.0 MB DATE   936d95    4:2                22
+  sd/sheep/allocator     0   16 PB   92 MB  0.0 MB DATE   fd57fc    4:2                22


### PR DESCRIPTION
The out file of this test is incorrect.

The default value of "-r" option is "host=localhost".
but, sheepdog process is down, if "host=localhost" is passed to the argument of FCGX_OpenSocket function.

Signed-off-by: Yasuhito Fukuda <fukuda.yasuhito@po.ntts.co.jp>
Signed-off-by: Satoshi Kuramochi <act.kura@gmail.com>