### PR TITLE
dog: Make "dog node recovery set-throttle" reject negative values

### DIFF
--- a/dog/node.c
+++ b/dog/node.c
@@ -248,23 +248,25 @@ static int node_recovery_set(int argc, char **argv)
 		exit(EXIT_USAGE);
 	}
 
-	rthrottling->max_exec_count = strtoul(argv[optind], &p, 10);
-	if (argv[optind] == p || rthrottling->max_exec_count < 0 ||
-	 UINT32_MAX <= rthrottling->max_exec_count || errno != 0 ||
-	 *p != '\0') {
+	/* clear errno before calling strtol */
+	errno = 0;
+
+	const long max = strtol(argv[optind], &p, 10);
+	if (argv[optind] == p || errno != 0 || *p != '\0' ||
+	    max < 0L || (int64_t)UINT32_MAX < (int64_t)max) {
 		sd_err("Invalid max (%s)", argv[optind]);
 		exit(EXIT_USAGE);
 	}
+	rthrottling->max_exec_count = (uint32_t)max;
 
 	optind++;
 
-	rthrottling->queue_work_interval = strtoull(argv[optind], &p, 10);
-	if (argv[optind] == p || rthrottling->queue_work_interval < 0 ||
-	 UINT64_MAX <= rthrottling->queue_work_interval || errno != 0 ||
-	 *p != '\0') {
+	const long long interval = strtoll(argv[optind], &p, 10);
+	if (argv[optind] == p || errno != 0 || *p != '\0' || interval < 0LL) {
 		sd_err("Invalid interval (%s)", argv[optind]);
 		exit(EXIT_USAGE);
 	}
+	rthrottling->queue_work_interval = (uint64_t)interval;
 
 	if ((rthrottling->max_exec_count == 0 &&
 	 rthrottling->queue_work_interval != 0) ||


### PR DESCRIPTION
This commit replaces strtoul/strtoull (pay attention to &quot;u&quot;) with strtol/strtoll (no &quot;u&quot;) to check negative values right.

Passing negative values to &quot;dog node recovery set-throttle,&quot; I got below. The case -1 is as I expected, but the case -2 is not:

    $ dog node recovery get-throttle
    max(0), interval (0)

    $ dog node recovery set-throttle -- -1 -1
    Invalid max (-1)
    $ dog node recovery get-throttle
    max (0), interval (0)

    $ dog node recovery set-throttle -- -2 -2
    $ dog node recovery get-throttle
    max (4294967294), interval (18446744073709551614)

This is because of strtoul/strtoull. These functions accept a string beginning with minus sign then, if non-negated value does not overflow, return the conversion represented as an unsigned value without error. So I got (uint32_t)(unsigned long)-2 and (uint64_t)(unsigned long long)-2.

Signed-off-by: Takashi Menjo &lt;menjo.takashi@lab.ntt.co.jp&gt;