### PR TITLE
sheep: Validate -p/--port, -z/--zone and -V/--vnodes values strictly

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -575,4 +575,6 @@ static inline uint64_t clock_get_time(void)
 }
 
 char *xstrdup(const char *s);
+uint32_t str_to_u32(const char *nptr);
+uint16_t str_to_u16(const char *nptr);
 #endif

--- a/lib/util.c
+++ b/lib/util.c
@@ -648,3 +648,45 @@ char *xstrdup(const char *s)
 	return ret;
 }
 
+/*
+ * Convert a decimal string like as strtoll to uint32_t/uint16_t
+ *
+ * returns:
+ *   - a converted value if success i.e. neither negative value nor overflow
+ *   - undefined if something went wrong and set errno accordingly
+ *
+ * errno:
+ *   - 0 if success
+ *   - EINVAL if one of the following:
+ *       - nptr was an empty string
+ *       - there was an unconvertible character in nptr
+ *   - ERANGE if negative/positive overflow occurred
+ */
+uint32_t str_to_u32(const char *nptr)
+{
+	char *endptr;
+	errno = 0;
+	const long long conv = strtoll(nptr, &endptr, 10);
+	/* empty string or unconvertible character */
+	if (nptr == endptr || *endptr != '\0') {
+		errno = EINVAL;
+		return (uint32_t)conv;
+	}
+	/* negative value or overflow */
+	if (conv < 0LL || UINT32_MAX < conv) {
+		errno = ERANGE;
+		return UINT32_MAX;
+	}
+	return (uint32_t)conv;
+}
+
+uint16_t str_to_u16(const char *nptr)
+{
+	const uint32_t conv = str_to_u32(nptr);
+	/* overflow */
+	if (UINT16_MAX < conv) {
+		errno = ERANGE;
+		return UINT16_MAX;
+	}
+	return (uint16_t)conv;
+}

--- a/sheep/sheep.c
+++ b/sheep/sheep.c
@@ -697,7 +697,7 @@ int main(int argc, char **argv)
 	int ch, longindex, ret, port = SD_LISTEN_PORT, io_port = SD_LISTEN_PORT;
 	int rc = 1;
 	const char *dirp = DEFAULT_OBJECT_DIR, *short_options;
-	char *dir, *p, *pid_file = NULL, *bindaddr = NULL, log_path[PATH_MAX],
+	char *dir, *pid_file = NULL, *bindaddr = NULL, log_path[PATH_MAX],
 	     *argp = NULL;
 	bool explicit_addr = false;
 	bool daemonize = true;
@@ -730,9 +730,8 @@ int main(int argc, char **argv)
 				 &longindex)) >= 0) {
 		switch (ch) {
 		case 'p':
-			port = strtol(optarg, &p, 10);
-			if (optarg == p || port < 1 || UINT16_MAX < port
-				|| *p != '\0') {
+			port = str_to_u16(optarg);
+			if (errno != 0 || port < 1) {
 				sd_err("Invalid port number '%s'", optarg);
 				exit(1);
 			}
@@ -773,9 +772,8 @@ int main(int argc, char **argv)
 			nr_vnodes = 0;
 			break;
 		case 'z':
-			zone = strtol(optarg, &p, 10);
-			if (optarg == p || zone < 0 || UINT32_MAX < zone
-				|| *p != '\0') {
+			zone = str_to_u32(optarg);
+			if (errno != 0) {
 				sd_err("Invalid zone id '%s': must be "
 				       "an integer between 0 and %u", optarg,
 				       UINT32_MAX);
@@ -866,9 +864,8 @@ int main(int argc, char **argv)
 				sd_err("Options '-g' and '-V' can not be both specified");
 				exit(1);
 			}
-			nr_vnodes = strtol(optarg, &p, 10);
-			if (optarg == p || nr_vnodes < 1
-				|| UINT16_MAX < nr_vnodes || *p != '\0') {
+			nr_vnodes = str_to_u16(optarg);
+			if (errno != 0 || nr_vnodes < 1) {
 				sd_err("Invalid number of vnodes '%s': must be "
 					"an integer between 1 and %u",
 					optarg, UINT16_MAX);

--- a/tests/functional/108
+++ b/tests/functional/108
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Test sheep -p/--port
+
+. ./common
+
+err=0
+
+function testStartPortSucceeded
+{
+	port="$1"
+	mkdir -p "$STORE/0"
+	if $SHEEP "$STORE/0" -p "$port" ; then
+		sleep 1 # DO NOT use _wait_for_sheep
+		if grep daemon "$STORE/0/sheep.log" >/dev/null 2>&1 ; then
+			$DOG node list -p "$port"
+		else
+			err=1
+		fi
+	else
+		err=1
+	fi
+	_cleanup
+}
+
+function testStartPortFailed
+{
+	port="$1"
+	mkdir -p "$STORE/0"
+	$SHEEP "$STORE/0" -p "$port" && err=1
+	_cleanup
+}
+
+testStartPortSucceeded 7000
+testStartPortSucceeded 65535 # UINT16_MAX
+testStartPortFailed 0
+testStartPortFailed 65536 # UINT16_MAX + 1
+testStartPortFailed 65537 # UINT16_MAx + 2
+testStartPortFailed 4294967297 # UINT32_MAX + 2
+testStartPortFailed -1
+testStartPortFailed a
+testStartPortFailed 42a
+testStartPortFailed +
+testStartPortFailed -
+
+exit $err

--- a/tests/functional/108.out
+++ b/tests/functional/108.out
@@ -1,0 +1,14 @@
+QA output created by 108
+  Id   Host:Port         V-Nodes       Zone
+   0   127.0.0.1:7000      	128   16777343
+  Id   Host:Port         V-Nodes       Zone
+   0   127.0.0.1:65535     	128   16777343
+Invalid port number '0'
+Invalid port number '65536'
+Invalid port number '65537'
+Invalid port number '4294967297'
+Invalid port number '-1'
+Invalid port number 'a'
+Invalid port number '42a'
+Invalid port number '+'
+Invalid port number '-'

--- a/tests/functional/109
+++ b/tests/functional/109
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Test sheep -z/--zone
+
+. ./common
+
+err=0
+
+function testStartZoneSucceeded
+{
+	zone="$1"
+	mkdir -p "$STORE/0"
+	if $SHEEP "$STORE/0" -z "$zone" ; then
+		_wait_for_sheep 1
+		if grep daemon "$STORE/0/sheep.log" >/dev/null 2>&1 ; then
+			$DOG node list
+		else
+			err=1
+		fi
+	else
+		err=1
+	fi
+	_cleanup
+}
+
+function testStartZoneFailed
+{
+	zone="$1"
+	mkdir -p "$STORE/0"
+	$SHEEP "$STORE/0" -z "$zone" && err=1
+	_cleanup
+}
+
+testStartZoneSucceeded 0
+testStartZoneSucceeded 1
+testStartZoneSucceeded 4294967295 # UINT32_MAX
+testStartZoneFailed 4294967296 # UINT32_MAX + 1
+testStartZoneFailed 9223372036854775808 # INT64_MAX + 1
+testStartZoneFailed -1
+testStartZoneFailed a
+testStartZoneFailed 42a
+testStartZoneFailed +
+testStartZoneFailed -
+
+exit $err

--- a/tests/functional/109.out
+++ b/tests/functional/109.out
@@ -1,0 +1,14 @@
+QA output created by 109
+  Id   Host:Port         V-Nodes       Zone
+   0   127.0.0.1:7000      	128          0
+  Id   Host:Port         V-Nodes       Zone
+   0   127.0.0.1:7000      	128          1
+  Id   Host:Port         V-Nodes       Zone
+   0   127.0.0.1:7000      	128 4294967295
+Invalid zone id '4294967296': must be an integer between 0 and 4294967295
+Invalid zone id '9223372036854775808': must be an integer between 0 and 4294967295
+Invalid zone id '-1': must be an integer between 0 and 4294967295
+Invalid zone id 'a': must be an integer between 0 and 4294967295
+Invalid zone id '42a': must be an integer between 0 and 4294967295
+Invalid zone id '+': must be an integer between 0 and 4294967295
+Invalid zone id '-': must be an integer between 0 and 4294967295

--- a/tests/functional/110
+++ b/tests/functional/110
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Test sheep -V/--vnodes
+
+. ./common
+
+function testStartVnodesFailed
+{
+	( SHEEP_OPTIONS="-V $1" _start_sheep 0 ) && :
+	_wait_for_sheep_stop 0
+	_cleanup
+}
+
+function testStartVnodesSucceeded
+{
+	SHEEP_OPTIONS="-V $1" _start_sheep 0
+	_wait_for_sheep 1
+	$DOG node list
+	_cleanup
+}
+
+function testStartVnodesGatewayFailed
+{
+	( SHEEP_OPTIONS='-g -V 42' _start_sheep 0 ) && :
+	_wait_for_sheep_stop 0
+	_cleanup
+}
+
+testStartVnodesSucceeded 1
+testStartVnodesSucceeded 65535 # UINT16_MAX
+testStartVnodesFailed 0
+testStartVnodesFailed 65536 # UINT16_MAX + 1
+testStartVnodesFailed 65537 # UINT16_MAX + 2
+testStartVnodesFailed 4294967297 # UINT32_MAX + 2
+testStartVnodesFailed -1
+testStartVnodesFailed a
+testStartVnodesFailed 42a
+testStartVnodesFailed +
+testStartVnodesFailed -
+testStartVnodesGatewayFailed

--- a/tests/functional/110.out
+++ b/tests/functional/110.out
@@ -1,0 +1,25 @@
+QA output created by 110
+  Id   Host:Port         V-Nodes       Zone
+   0   127.0.0.1:7000      	 1          0
+  Id   Host:Port         V-Nodes       Zone
+   0   127.0.0.1:7000      	65535          0
+Invalid number of vnodes '0': must be an integer between 1 and 65535
+cannot start sheep 0
+Invalid number of vnodes '65536': must be an integer between 1 and 65535
+cannot start sheep 0
+Invalid number of vnodes '65537': must be an integer between 1 and 65535
+cannot start sheep 0
+Invalid number of vnodes '4294967297': must be an integer between 1 and 65535
+cannot start sheep 0
+Invalid number of vnodes '-1': must be an integer between 1 and 65535
+cannot start sheep 0
+Invalid number of vnodes 'a': must be an integer between 1 and 65535
+cannot start sheep 0
+Invalid number of vnodes '42a': must be an integer between 1 and 65535
+cannot start sheep 0
+Invalid number of vnodes '+': must be an integer between 1 and 65535
+cannot start sheep 0
+Invalid number of vnodes '-': must be an integer between 1 and 65535
+cannot start sheep 0
+Options '-g' and '-V' can not be both specified
+cannot start sheep 0

--- a/tests/functional/group
+++ b/tests/functional/group
@@ -115,3 +115,6 @@
 105 auto quick vdi
 106 auto quick vdi
 107 auto quick dog
+108 auto quick
+109 auto quick
+110 auto quick

--- a/tests/unit/lib/test_util.c
+++ b/tests/unit/lib/test_util.c
@@ -1,9 +1,12 @@
+#include <stdint.h>
 #include <stdlib.h>
 #include <unity.h>
 #include <cmock.h>
 
 #include "util.h"
 #include "Mocklogger.h"
+
+/* is_numeric */
 
 static void test_is_numeric_returns_true_if_valid_octet(void)
 {
@@ -36,6 +39,190 @@ static void test_is_numeric_returns_false_if_non_digit_contained(void)
 	TEST_ASSERT_FALSE(is_numeric(" 0")); // whitespace contained
 }
 
+/* str_to_u32 */
+
+static void assert_str_to_u32(uint32_t expected, const char *nptr)
+{
+	errno = 0;
+	const uint32_t actual = str_to_u32(nptr);
+	const int err = errno;
+	TEST_ASSERT_EQUAL_INT(0, err);
+	TEST_ASSERT_EQUAL_UINT32(expected, actual);
+}
+
+#define assert_str_to_u32_success(n) assert_str_to_u32(n, #n)
+
+static void assert_str_to_u32_error(int expected, const char *nptr)
+{
+	errno = 0;
+	str_to_u32(nptr);
+	const int actual = errno;
+	TEST_ASSERT_EQUAL_INT(expected, actual);
+}
+
+static void assert_str_to_u32_ERANGE(const char *nptr)
+{
+	assert_str_to_u32_error(ERANGE, nptr);
+}
+
+static void assert_str_to_u32_EINVAL(const char *nptr)
+{
+	assert_str_to_u32_error(EINVAL, nptr);
+}
+
+static void test_str_to_u32_success(void)
+{
+	assert_str_to_u32_success(0);
+	assert_str_to_u32_success(1);
+	assert_str_to_u32_success(2);
+	/* INT16_MAX {-1/+0/+1} */
+	assert_str_to_u32_success(32766);
+	assert_str_to_u32_success(32767);
+	assert_str_to_u32_success(32768);
+	/* UINT16_MAX {-1/+0/+1} */
+	assert_str_to_u32_success(65534);
+	assert_str_to_u32_success(65535);
+	assert_str_to_u32_success(65536);
+	/* INT32_MAX {-1/+0/+1} */
+	assert_str_to_u32_success(2147483646);
+	assert_str_to_u32_success(2147483647);
+	assert_str_to_u32_success(2147483648);
+	/* UINT32_MAX {-1/+0} */
+	assert_str_to_u32_success(4294967294);
+	assert_str_to_u32_success(4294967295);
+}
+
+static void test_str_to_u32_ERANGE(void)
+{
+	/* UINT32_MAX +1 */
+	assert_str_to_u32_ERANGE("4294967296");
+	/* INT64_MAX {-1/+0/+1} */
+	assert_str_to_u32_ERANGE("9223372036854775806");
+	assert_str_to_u32_ERANGE("9223372036854775807");
+	assert_str_to_u32_ERANGE("9223372036854775808");
+	/* UINT64_MAX {-1/+0/+1} */
+	assert_str_to_u32_ERANGE("18446744073709551614");
+	assert_str_to_u32_ERANGE("18446744073709551615");
+	assert_str_to_u32_ERANGE("18446744073709551616");
+	/* INT64_MIN {-1/+0/+1} */
+	assert_str_to_u32_ERANGE("-9223372036854775809");
+	assert_str_to_u32_ERANGE("-9223372036854775808");
+	assert_str_to_u32_ERANGE("-9223372036854775807");
+	/* INT32_MIN {-1/+0/+1} */
+	assert_str_to_u32_ERANGE("-2147483649");
+	assert_str_to_u32_ERANGE("-2147483648");
+	assert_str_to_u32_ERANGE("-2147483647");
+	/* INT16_MIN {-1/+0/+1} */
+	assert_str_to_u32_ERANGE("-32769");
+	assert_str_to_u32_ERANGE("-32768");
+	assert_str_to_u32_ERANGE("-32767");
+
+	assert_str_to_u32_ERANGE("-2");
+	assert_str_to_u32_ERANGE("-1");
+}
+
+static void test_str_to_u32_EINVAL(void)
+{
+	assert_str_to_u32_EINVAL("");
+	assert_str_to_u32_EINVAL(" ");
+	assert_str_to_u32_EINVAL("+");
+	assert_str_to_u32_EINVAL("-");
+	assert_str_to_u32_EINVAL("a");
+	assert_str_to_u32_EINVAL("42a");
+}
+
+/* str_to_u16 */
+
+static void assert_str_to_u16(uint16_t expected, const char *nptr)
+{
+	errno = 0;
+	const uint16_t actual = str_to_u16(nptr);
+	const int err = errno;
+	TEST_ASSERT_EQUAL_INT(0, err);
+	TEST_ASSERT_EQUAL_UINT16(expected, actual);
+}
+
+#define assert_str_to_u16_success(n) assert_str_to_u16(n, #n)
+
+static void assert_str_to_u16_error(int expected, const char *nptr)
+{
+	errno = 0;
+	str_to_u16(nptr);
+	const int actual = errno;
+	TEST_ASSERT_EQUAL_INT(expected, actual);
+}
+
+static void assert_str_to_u16_ERANGE(const char *nptr)
+{
+	assert_str_to_u16_error(ERANGE, nptr);
+}
+
+static void assert_str_to_u16_EINVAL(const char *nptr)
+{
+	assert_str_to_u16_error(EINVAL, nptr);
+}
+
+static void test_str_to_u16_success(void)
+{
+	assert_str_to_u16_success(0);
+	assert_str_to_u16_success(1);
+	assert_str_to_u16_success(2);
+	/* INT16_MAX {-1/+0/+1} */
+	assert_str_to_u16_success(32766);
+	assert_str_to_u16_success(32767);
+	assert_str_to_u16_success(32768);
+	/* UINT16_MAX {-1/+0} */
+	assert_str_to_u16_success(65534);
+	assert_str_to_u16_success(65535);
+}
+
+static void test_str_to_u16_ERANGE(void)
+{
+	/* UINT16_MAX +1 */
+	assert_str_to_u16_ERANGE("65536");
+	/* INT32_MAX {-1/+0/+1} */
+	assert_str_to_u16_ERANGE("2147483646");
+	assert_str_to_u16_ERANGE("2147483647");
+	assert_str_to_u16_ERANGE("2147483648");
+	/* UINT32_MAX {-1/+0} */
+	assert_str_to_u16_ERANGE("4294967294");
+	assert_str_to_u16_ERANGE("4294967295");
+	assert_str_to_u16_ERANGE("4294967296");
+	/* INT64_MAX {-1/+0/+1} */
+	assert_str_to_u16_ERANGE("9223372036854775806");
+	assert_str_to_u16_ERANGE("9223372036854775807");
+	assert_str_to_u16_ERANGE("9223372036854775808");
+	/* UINT64_MAX {-1/+0/+1} */
+	assert_str_to_u16_ERANGE("18446744073709551614");
+	assert_str_to_u16_ERANGE("18446744073709551615");
+	assert_str_to_u16_ERANGE("18446744073709551616");
+	/* INT64_MIN {-1/+0/+1} */
+	assert_str_to_u16_ERANGE("-9223372036854775809");
+	assert_str_to_u16_ERANGE("-9223372036854775808");
+	assert_str_to_u16_ERANGE("-9223372036854775807");
+	/* INT32_MIN {-1/+0/+1} */
+	assert_str_to_u16_ERANGE("-2147483649");
+	assert_str_to_u16_ERANGE("-2147483648");
+	assert_str_to_u16_ERANGE("-2147483647");
+	/* INT16_MIN {-1/+0/+1} */
+	assert_str_to_u16_ERANGE("-32769");
+	assert_str_to_u16_ERANGE("-32768");
+	assert_str_to_u16_ERANGE("-32767");
+
+	assert_str_to_u16_ERANGE("-2");
+	assert_str_to_u16_ERANGE("-1");
+}
+
+static void test_str_to_u16_EINVAL(void)
+{
+	assert_str_to_u16_EINVAL("");
+	assert_str_to_u16_EINVAL(" ");
+	assert_str_to_u16_EINVAL("+");
+	assert_str_to_u16_EINVAL("-");
+	assert_str_to_u16_EINVAL("a");
+	assert_str_to_u16_EINVAL("42a");
+}
+
 int main(int argc, char **argv)
 {
 	UNITY_BEGIN();
@@ -43,5 +230,11 @@ int main(int argc, char **argv)
 	RUN_TEST(test_is_numeric_returns_true_if_invalid_octet);
 	RUN_TEST(test_is_numeric_returns_true_if_decimal);
 	RUN_TEST(test_is_numeric_returns_false_if_non_digit_contained);
+	RUN_TEST(test_str_to_u32_success);
+	RUN_TEST(test_str_to_u32_ERANGE);
+	RUN_TEST(test_str_to_u32_EINVAL);
+	RUN_TEST(test_str_to_u16_success);
+	RUN_TEST(test_str_to_u16_ERANGE);
+	RUN_TEST(test_str_to_u16_EINVAL);
 	return UNITY_END();
 }


### PR DESCRIPTION
This PR adds two functions str_to_u32 and str_to_u16 to lib/util.c. These functions convert a string into a 64-bit integer with strtoll. Then they check whether a converted value is in the valid range or not and, if something goes wrong because of an empty string, an invalid character, a negative value or overflow, sets errno accordingly.

Using them, this enforces strict range validation of -p/--port, -z/--zone and -V/--vnodes.

This also adds some unit and functional tests to verify the change.

Fixes #296

Signed-off-by: Takashi Menjo &lt;menjo.takashi@lab.ntt.co.jp&gt;