### PR TITLE
dog: Validate "dog node vnodes set" value strictly

### DIFF
--- a/dog/node.c
+++ b/dog/node.c
@@ -789,11 +789,9 @@ static int do_vnodes_set(const struct node_id *nid, int *nr_vnodes)
 static int node_vnodes_set(int argc, char **argv)
 {
 	int ret = 0;
-	char *p;
-	int32_t nr_vnodes = strtol(argv[optind], &p, 10);
+	int32_t nr_vnodes = str_to_u16(argv[optind]);
 
-	if (argv[optind] == p || nr_vnodes < 1 || nr_vnodes > UINT16_MAX
-		|| *p != '\0') {
+	if (errno != 0 || nr_vnodes < 1) {
 		sd_err("Invalid number of vnodes '%s': must be an integer "
 			"between 1 and %u",
 			argv[optind], UINT16_MAX);

--- a/tests/functional/111
+++ b/tests/functional/111
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Test sheep -V/--vnodes
+
+. ./common
+
+err=0
+
+function setUpFixedCluster
+{
+	SHEEP_OPTIONS='-V 100' _start_sheep 0
+	_wait_for_sheep 1
+	$DOG cluster format -V -c 1
+}
+
+function testSetVnodesSucceeded
+{
+	setUpFixedCluster
+	$DOG cluster info -v | _filter_cluster_info
+	$DOG node vnodes set -- "$1" || err=1
+	_wait_for_sheep_recovery 0
+	$DOG cluster info -v | _filter_cluster_info
+	_cleanup
+}
+
+function testSetVnodesFailed
+{
+	setUpFixedCluster
+	$DOG node vnodes set -- "$1" && err=1
+	_cleanup
+}
+
+testSetVnodesSucceeded 1
+testSetVnodesSucceeded 65535 # UINT16_MAX
+
+testSetVnodesFailed 0
+testSetVnodesFailed 65536 # UINT16_MAX + 1
+testSetVnodesFailed 65537 # UINT16_MAX + 2
+testSetVnodesFailed 4294967297 # UINT32_MAX + 2
+testSetVnodesFailed -1
+testSetVnodesFailed a
+testSetVnodesFailed 42a
+testSetVnodesFailed +
+testSetVnodesFailed -
+
+exit $err

--- a/tests/functional/111.out
+++ b/tests/functional/111.out
@@ -1,0 +1,55 @@
+QA output created by 111
+using backend plain store
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 1 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      1 [127.0.0.1:7000:100]
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 1 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      2 [127.0.0.1:7000:1]
+DATE      1 [127.0.0.1:7000:100]
+using backend plain store
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 1 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      1 [127.0.0.1:7000:100]
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 1 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      2 [127.0.0.1:7000:65535]
+DATE      1 [127.0.0.1:7000:100]
+using backend plain store
+Invalid number of vnodes '0': must be an integer between 1 and 65535
+using backend plain store
+Invalid number of vnodes '65536': must be an integer between 1 and 65535
+using backend plain store
+Invalid number of vnodes '65537': must be an integer between 1 and 65535
+using backend plain store
+Invalid number of vnodes '4294967297': must be an integer between 1 and 65535
+using backend plain store
+Invalid number of vnodes '-1': must be an integer between 1 and 65535
+using backend plain store
+Invalid number of vnodes 'a': must be an integer between 1 and 65535
+using backend plain store
+Invalid number of vnodes '42a': must be an integer between 1 and 65535
+using backend plain store
+Invalid number of vnodes '+': must be an integer between 1 and 65535
+using backend plain store
+Invalid number of vnodes '-': must be an integer between 1 and 65535

--- a/tests/functional/group
+++ b/tests/functional/group
@@ -118,3 +118,4 @@
 108 auto quick
 109 auto quick
 110 auto quick
+111 auto quick dog


### PR DESCRIPTION
This PR enforces strict range validation of `dog node vnodes set` like as the commit c19170a in PR #297.

This also add a functional test 111 for regression testing.