### PR TITLE
tests: Add functional tests 112 and 113 to test fixed vnodes feature

### DIFF
--- a/tests/functional/112
+++ b/tests/functional/112
@@ -1,0 +1,179 @@
+#!/bin/bash
+
+# Test fixed vnodes feature
+
+. ./common
+
+_need_to_be_root
+
+function setUpDevice
+{
+	_make_device 0 $((100*1024**2))
+	_make_device 1 $((200*1024**2))
+	_make_device 2 $((300*1024**2))
+}
+
+function setUpAutoNode
+{
+	SHEEP_OPTIONS='' _start_sheep 0
+	SHEEP_OPTIONS='' _start_sheep 1
+	SHEEP_OPTIONS='' _start_sheep 2
+	_wait_for_sheep 3
+}
+
+function setUpAutoCluster
+{
+	setUpDevice
+	setUpAutoNode
+	_cluster_format -c 2
+}
+
+function setUpFixedNode
+{
+	SHEEP_OPTIONS='-V 100' _start_sheep 0
+	SHEEP_OPTIONS='-V 200' _start_sheep 1
+	SHEEP_OPTIONS='-V 300' _start_sheep 2
+	_wait_for_sheep 3
+}
+
+function setUpFixedCluster
+{
+	setUpDevice
+	setUpFixedNode
+	_cluster_format -V -c 2
+}
+
+function setUpClusterShutdown
+{
+	"$1" # setUpFoobarCluster
+	$DOG cluster shutdown
+	for i in 0 1 2 ; do
+		_wait_for_sheep_stop "$i"
+	done
+}
+
+function testFormatAutoCluster
+{
+	setUpAutoNode
+
+	# format failed with -V
+	( _cluster_format -V -c 2 ) && _die
+
+	# format succeeded without -V
+	_cluster_format -c 2
+	$DOG cluster info -v | _filter_cluster_info
+
+	# reformat failed with -V
+	( _cluster_format -V -c 2 ) && _die
+
+	# reformat succeeded without -V
+	_cluster_format -c 2
+
+	_cleanup
+}
+
+function testFormatFixedCluster
+{
+	setUpFixedNode
+
+	# format failed without -V
+	( _cluster_format -c 2 ) && _die
+
+	# format succeeded with -V
+	_cluster_format -V -c 2
+	$DOG cluster info -v | _filter_cluster_info
+
+	# format failed without -V
+	( _cluster_format -c 2 ) && _die
+
+	# format succeeded with -V
+	_cluster_format -V -c 2
+
+	_cleanup
+}
+
+function testFormatMixedClusterFailed
+{
+	_make_device 0 $((100*1024**2))
+	_make_device 1 $((200*1024**2))
+	_make_device 2 $((300*1024**2))
+	_make_device 3 $((400*1024**2))
+	SHEEP_OPTIONS=''       _start_sheep 0
+	SHEEP_OPTIONS='-V 200' _start_sheep 1
+	SHEEP_OPTIONS=''       _start_sheep 2
+	SHEEP_OPTIONS='-V 400' _start_sheep 3
+	_wait_for_sheep 4
+
+	# format failed with or without -V
+	( _cluster_format    -c 2 ) && _die
+	( _cluster_format -V -c 2 ) && _die
+
+	_cleanup
+}
+
+# Give me SHEEP_OPTIONS when you call testJoinSucceeded
+function testJoinSucceeded
+{
+	"$1" # setUpFoobarCluster
+	$DOG cluster info -v | _filter_cluster_info
+
+	_make_device 3 $((400*1024**2))
+	_start_sheep 3
+	_wait_for_sheep 4
+	for i in 0 1 2 3 ; do
+		_wait_for_sheep_recovery "$i"
+	done
+	$DOG cluster info -v | _filter_cluster_info
+
+	_cleanup
+}
+
+# Give me SHEEP_OPTIONS when you call testJoinFailed
+function testJoinFailed
+{
+	"$1" # setUpFoobarCluster
+	$DOG cluster info -v | _filter_cluster_info
+
+	_make_device 3 $((400*1024**2))
+	_start_sheep 3
+	_wait_for_sheep_stop 3
+	_wait_for_sheep 3
+	for i in 0 1 2 ; do
+		_wait_for_sheep_recovery "$i"
+	done
+	$DOG cluster info -v | _filter_cluster_info
+
+	_cleanup
+}
+
+function testRejoinSucceeded
+{
+	setUpClusterShutdown "$1" # setUpFoobarCluster
+	"$2" # setUpFoobarNode
+	_cleanup
+}
+
+# Give me SHEEP_OPTIONS when you call testRejoinFailed
+function testRejoinFailed
+{
+	setUpClusterShutdown "$1" # setUpFoobarCluster
+	_start_sheep 0
+	_wait_for_sheep_stop 0
+	_cleanup
+}
+
+testFormatAutoCluster
+testFormatFixedCluster
+testFormatMixedClusterFailed
+
+SHEEP_OPTIONS=''       testJoinSucceeded setUpAutoCluster
+SHEEP_OPTIONS='-V 400' testJoinSucceeded setUpFixedCluster
+SHEEP_OPTIONS=''       testJoinFailed    setUpFixedCluster
+SHEEP_OPTIONS='-V 400' testJoinFailed    setUpAutoCluster
+
+testRejoinSucceeded setUpAutoCluster  setUpAutoNode
+testRejoinSucceeded setUpFixedCluster setUpFixedNode
+
+SHEEP_OPTIONS='-V 42' testRejoinFailed setUpAutoCluster
+SHEEP_OPTIONS=''      testRejoinFailed setUpFixedCluster
+SHEEP_OPTIONS='-V 42' testRejoinFailed setUpFixedCluster

--- a/tests/functional/112.out
+++ b/tests/functional/112.out
@@ -1,0 +1,112 @@
+QA output created by 112
+Can not apply the option of '-V', because there are vnode strategy of sheep is auto in the cluster
+failed to format cluster
+using backend plain store
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: auto
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      1 [127.0.0.1:7000:128, 127.0.0.1:7001:128, 127.0.0.1:7002:128]
+Can not apply the option of '-V', because there are vnode strategy of sheep is auto in the cluster
+failed to format cluster
+using backend plain store
+Need to specify the option of '-V', because there are vnode strategy of sheep is fixed in the cluster
+failed to format cluster
+using backend plain store
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      1 [127.0.0.1:7000:100, 127.0.0.1:7001:200, 127.0.0.1:7002:300]
+Need to specify the option of '-V', because there are vnode strategy of sheep is fixed in the cluster
+failed to format cluster
+using backend plain store
+Need to specify the option of '-V', because there are vnode strategy of sheep is fixed in the cluster
+failed to format cluster
+Can not apply the option of '-V', because there are vnode strategy of sheep is auto in the cluster
+failed to format cluster
+using backend plain store
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: auto
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      1 [127.0.0.1:7000:63, 127.0.0.1:7001:128, 127.0.0.1:7002:193]
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: auto
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      2 [127.0.0.1:7000:50, 127.0.0.1:7001:102, 127.0.0.1:7002:154, 127.0.0.1:7003:206]
+DATE      1 [127.0.0.1:7000:63, 127.0.0.1:7001:128, 127.0.0.1:7002:193]
+using backend plain store
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      1 [127.0.0.1:7000:100, 127.0.0.1:7001:200, 127.0.0.1:7002:300]
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      2 [127.0.0.1:7000:100, 127.0.0.1:7001:200, 127.0.0.1:7002:300, 127.0.0.1:7003:400]
+DATE      1 [127.0.0.1:7000:100, 127.0.0.1:7001:200, 127.0.0.1:7002:300]
+using backend plain store
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      1 [127.0.0.1:7000:100, 127.0.0.1:7001:200, 127.0.0.1:7002:300]
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      3 [127.0.0.1:7000:100, 127.0.0.1:7001:200, 127.0.0.1:7002:300]
+DATE      2 [127.0.0.1:7000:100, 127.0.0.1:7001:200, 127.0.0.1:7002:300, 127.0.0.1:7003:128]
+DATE      1 [127.0.0.1:7000:100, 127.0.0.1:7001:200, 127.0.0.1:7002:300]
+using backend plain store
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: auto
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      1 [127.0.0.1:7000:63, 127.0.0.1:7001:128, 127.0.0.1:7002:193]
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: auto
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      3 [127.0.0.1:7000:63, 127.0.0.1:7001:128, 127.0.0.1:7002:193]
+DATE      2 [127.0.0.1:7000:50, 127.0.0.1:7001:102, 127.0.0.1:7002:154, 127.0.0.1:7003:206]
+DATE      1 [127.0.0.1:7000:63, 127.0.0.1:7001:128, 127.0.0.1:7002:193]
+using backend plain store
+using backend plain store
+using backend plain store
+using backend plain store
+using backend plain store

--- a/tests/functional/113
+++ b/tests/functional/113
@@ -1,0 +1,153 @@
+#!/bin/bash
+
+# Test fixed vnodes feature more
+
+. ./common
+
+_need_to_be_root
+
+function setUpCluster3
+{
+	_make_device 0 $((200*1024**2))
+	_make_device 1 $((100*1024**2))
+	_make_device 2 $((100*1024**2))
+	SHEEP_OPTIONS='-V 200' _start_sheep 0
+	SHEEP_OPTIONS='-V 100' _start_sheep 1
+	SHEEP_OPTIONS='-V 100' _start_sheep 2
+	_wait_for_sheep 3
+	_cluster_format -V -c 2
+}
+
+function setUpCluster4
+{
+	_make_device 0 $((200*1024**2))
+	_make_device 1 $((100*1024**2))
+	_make_device 2 $((100*1024**2))
+	_make_device 3 $((100*1024**2))
+	SHEEP_OPTIONS='-V 200' _start_sheep 0
+	SHEEP_OPTIONS='-V 100' _start_sheep 1
+	SHEEP_OPTIONS='-V 100' _start_sheep 2
+	SHEEP_OPTIONS='-V 100' _start_sheep 3
+	_wait_for_sheep 4
+	_cluster_format -V -c 2
+}
+
+function testJoinCluster
+{
+	setUpCluster3
+	$DOG cluster info -v | _filter_cluster_info
+	$DOG vdi create -P foo 100M >/dev/null 2>&1
+	$DOG node info
+
+	_make_device 3 $((100*1024**2))
+	SHEEP_OPTIONS='-V 100' _start_sheep 3
+	_wait_for_sheep 4
+	for i in 0 1 2 3 ; do
+		_wait_for_sheep_recovery "$i"
+	done
+
+	$DOG cluster info -v | _filter_cluster_info
+	$DOG node info
+	_cleanup
+}
+
+function testLeaveCluster
+{
+	setUpCluster4
+	$DOG cluster info -v | _filter_cluster_info
+	$DOG vdi create -P foo 100M >/dev/null 2>&1
+	$DOG node info
+
+	_kill_sheep 3
+	_wait_for_sheep_stop 3
+	_wait_for_sheep 3
+	for i in 0 1 2 ; do
+		_wait_for_sheep_recovery "$i"
+	done
+
+	$DOG cluster info -v | _filter_cluster_info
+	$DOG node info
+	_cleanup
+}
+
+function testReweightCluster
+{
+	setUpCluster3
+	$DOG cluster info -v | _filter_cluster_info
+	$DOG vdi create -P foo 100M >/dev/null 2>&1
+	$DOG node info
+
+	dd if=/dev/zero of="$STORE/0/dummy" bs=1024k count=50 \
+		>/dev/null 2>&1
+	$DOG node info
+	$DOG cluster reweight
+	for i in 0 1 2 ; do
+		_wait_for_sheep_recovery "$i"
+	done
+
+	$DOG cluster info -v | _filter_cluster_info
+	$DOG node info
+	_cleanup
+}
+
+function testJoinClusterStepByStep
+{
+	setUpCluster3
+	$DOG cluster info -v | _filter_cluster_info
+	$DOG vdi create -P foo 100M >/dev/null 2>&1
+	$DOG node info
+
+	_make_device 3 $((100*1024**2))
+	SHEEP_OPTIONS='-V 10' _start_sheep 3
+	_wait_for_sheep 4
+	for i in 0 1 2 3 ; do
+		_wait_for_sheep_recovery "$i"
+	done
+	$DOG cluster info -v | _filter_cluster_info
+	$DOG node info
+
+	for ((vnodes=20 ; vnodes<=100 ; vnodes+=10)) ; do
+		$DOG node vnodes set -p 7003 "$vnodes"
+		for i in 0 1 2 3 ; do
+			_wait_for_sheep_recovery "$i"
+		done
+		$DOG cluster info -v | _filter_cluster_info
+		$DOG node info
+	done
+
+	_cleanup
+}
+
+function testLeaveClusterStepByStep
+{
+	setUpCluster4
+	$DOG cluster info -v | _filter_cluster_info
+	$DOG vdi create -P foo 100M >/dev/null 2>&1
+	$DOG node info
+
+	for ((vnodes=90 ; vnodes>=10 ; vnodes-=10)) ; do
+		$DOG node vnodes set -p 7003 "$vnodes"
+		for i in 0 1 2 3 ; do
+			_wait_for_sheep_recovery "$i"
+		done
+		$DOG cluster info -v | _filter_cluster_info
+		$DOG node info
+	done
+
+	_kill_sheep 3
+	_wait_for_sheep_stop 3
+	_wait_for_sheep 3
+	for i in 0 1 2 ; do
+		_wait_for_sheep_recovery "$i"
+	done
+	$DOG cluster info -v | _filter_cluster_info
+	$DOG node info
+
+	_cleanup
+}
+
+testJoinCluster
+testLeaveCluster
+testReweightCluster
+testJoinClusterStepByStep
+testLeaveClusterStepByStep

--- a/tests/functional/113.out
+++ b/tests/functional/113.out
@@ -1,0 +1,568 @@
+QA output created by 113
+using backend plain store
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      1 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100]
+Id	Size	Used	Avail	Use%
+ 0	178 MB	80 MB	98 MB	 44%
+ 1	88 MB	48 MB	40 MB	 54%
+ 2	88 MB	72 MB	16 MB	 81%
+Total	355 MB	200 MB	155 MB	 56%
+
+Total virtual image size	100 MB
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      2 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:100]
+DATE      1 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100]
+Id	Size	Used	Avail	Use%
+ 0	178 MB	64 MB	114 MB	 35%
+ 1	88 MB	40 MB	48 MB	 45%
+ 2	88 MB	60 MB	28 MB	 67%
+ 3	88 MB	36 MB	52 MB	 40%
+Total	443 MB	200 MB	243 MB	 45%
+
+Total virtual image size	100 MB
+using backend plain store
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      1 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:100]
+Id	Size	Used	Avail	Use%
+ 0	178 MB	64 MB	114 MB	 35%
+ 1	88 MB	40 MB	48 MB	 45%
+ 2	88 MB	60 MB	28 MB	 67%
+ 3	88 MB	36 MB	52 MB	 40%
+Total	443 MB	200 MB	243 MB	 45%
+
+Total virtual image size	100 MB
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      2 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100]
+DATE      1 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:100]
+Id	Size	Used	Avail	Use%
+ 0	178 MB	80 MB	98 MB	 44%
+ 1	88 MB	48 MB	40 MB	 54%
+ 2	88 MB	72 MB	16 MB	 81%
+Total	355 MB	200 MB	155 MB	 56%
+
+Total virtual image size	100 MB
+using backend plain store
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      1 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100]
+Id	Size	Used	Avail	Use%
+ 0	178 MB	80 MB	98 MB	 44%
+ 1	88 MB	48 MB	40 MB	 54%
+ 2	88 MB	72 MB	16 MB	 81%
+Total	355 MB	200 MB	155 MB	 56%
+
+Total virtual image size	100 MB
+Id	Size	Used	Avail	Use%
+ 0	128 MB	80 MB	48 MB	 62%
+ 1	88 MB	48 MB	40 MB	 54%
+ 2	88 MB	72 MB	16 MB	 81%
+Total	305 MB	200 MB	105 MB	 65%
+
+Total virtual image size	100 MB
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      2 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100]
+DATE      1 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100]
+Id	Size	Used	Avail	Use%
+ 0	128 MB	80 MB	48 MB	 62%
+ 1	88 MB	48 MB	40 MB	 54%
+ 2	88 MB	72 MB	16 MB	 81%
+Total	305 MB	200 MB	105 MB	 65%
+
+Total virtual image size	100 MB
+using backend plain store
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      1 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100]
+Id	Size	Used	Avail	Use%
+ 0	178 MB	80 MB	98 MB	 44%
+ 1	88 MB	48 MB	40 MB	 54%
+ 2	88 MB	72 MB	16 MB	 81%
+Total	355 MB	200 MB	155 MB	 56%
+
+Total virtual image size	100 MB
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      2 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:10]
+DATE      1 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100]
+Id	Size	Used	Avail	Use%
+ 0	178 MB	80 MB	98 MB	 44%
+ 1	88 MB	48 MB	40 MB	 54%
+ 2	88 MB	72 MB	16 MB	 81%
+ 3	88 MB	0.0 MB	88 MB	  0%
+Total	443 MB	200 MB	243 MB	 45%
+
+Total virtual image size	100 MB
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      3 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:20]
+DATE      2 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:10]
+DATE      1 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100]
+Id	Size	Used	Avail	Use%
+ 0	178 MB	76 MB	102 MB	 42%
+ 1	88 MB	48 MB	40 MB	 54%
+ 2	88 MB	64 MB	24 MB	 72%
+ 3	88 MB	12 MB	76 MB	 13%
+Total	443 MB	200 MB	243 MB	 45%
+
+Total virtual image size	100 MB
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      4 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:30]
+DATE      3 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:20]
+DATE      2 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:10]
+DATE      1 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100]
+Id	Size	Used	Avail	Use%
+ 0	178 MB	68 MB	110 MB	 38%
+ 1	88 MB	48 MB	40 MB	 54%
+ 2	88 MB	64 MB	24 MB	 72%
+ 3	88 MB	20 MB	68 MB	 22%
+Total	443 MB	200 MB	243 MB	 45%
+
+Total virtual image size	100 MB
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      5 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:40]
+DATE      4 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:30]
+DATE      3 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:20]
+DATE      2 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:10]
+DATE      1 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100]
+Id	Size	Used	Avail	Use%
+ 0	178 MB	68 MB	110 MB	 38%
+ 1	88 MB	44 MB	44 MB	 49%
+ 2	88 MB	64 MB	24 MB	 72%
+ 3	88 MB	24 MB	64 MB	 27%
+Total	443 MB	200 MB	243 MB	 45%
+
+Total virtual image size	100 MB
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      6 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:50]
+DATE      5 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:40]
+DATE      4 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:30]
+DATE      3 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:20]
+DATE      2 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:10]
+DATE      1 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100]
+Id	Size	Used	Avail	Use%
+ 0	178 MB	68 MB	110 MB	 38%
+ 1	88 MB	44 MB	44 MB	 49%
+ 2	88 MB	60 MB	28 MB	 67%
+ 3	88 MB	28 MB	60 MB	 31%
+Total	443 MB	200 MB	243 MB	 45%
+
+Total virtual image size	100 MB
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      7 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:60]
+DATE      6 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:50]
+DATE      5 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:40]
+DATE      4 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:30]
+DATE      3 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:20]
+DATE      2 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:10]
+DATE      1 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100]
+Id	Size	Used	Avail	Use%
+ 0	178 MB	68 MB	110 MB	 38%
+ 1	88 MB	44 MB	44 MB	 49%
+ 2	88 MB	60 MB	28 MB	 67%
+ 3	88 MB	28 MB	60 MB	 31%
+Total	443 MB	200 MB	243 MB	 45%
+
+Total virtual image size	100 MB
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      8 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:70]
+DATE      7 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:60]
+DATE      6 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:50]
+DATE      5 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:40]
+DATE      4 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:30]
+DATE      3 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:20]
+DATE      2 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:10]
+DATE      1 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100]
+Id	Size	Used	Avail	Use%
+ 0	178 MB	64 MB	114 MB	 35%
+ 1	88 MB	40 MB	48 MB	 45%
+ 2	88 MB	60 MB	28 MB	 67%
+ 3	88 MB	36 MB	52 MB	 40%
+Total	443 MB	200 MB	243 MB	 45%
+
+Total virtual image size	100 MB
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      9 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:80]
+DATE      8 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:70]
+DATE      7 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:60]
+DATE      6 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:50]
+DATE      5 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:40]
+DATE      4 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:30]
+DATE      3 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:20]
+DATE      2 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:10]
+DATE      1 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100]
+Id	Size	Used	Avail	Use%
+ 0	178 MB	64 MB	114 MB	 35%
+ 1	88 MB	40 MB	48 MB	 45%
+ 2	88 MB	60 MB	28 MB	 67%
+ 3	88 MB	36 MB	52 MB	 40%
+Total	443 MB	200 MB	243 MB	 45%
+
+Total virtual image size	100 MB
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE     10 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:90]
+DATE      9 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:80]
+DATE      8 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:70]
+DATE      7 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:60]
+DATE      6 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:50]
+DATE      5 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:40]
+DATE      4 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:30]
+DATE      3 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:20]
+DATE      2 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:10]
+DATE      1 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100]
+Id	Size	Used	Avail	Use%
+ 0	178 MB	64 MB	114 MB	 35%
+ 1	88 MB	40 MB	48 MB	 45%
+ 2	88 MB	60 MB	28 MB	 67%
+ 3	88 MB	36 MB	52 MB	 40%
+Total	443 MB	200 MB	243 MB	 45%
+
+Total virtual image size	100 MB
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE     11 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:100]
+DATE     10 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:90]
+DATE      9 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:80]
+DATE      8 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:70]
+DATE      7 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:60]
+DATE      6 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:50]
+DATE      5 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:40]
+DATE      4 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:30]
+DATE      3 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:20]
+DATE      2 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:10]
+DATE      1 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100]
+Id	Size	Used	Avail	Use%
+ 0	178 MB	64 MB	114 MB	 35%
+ 1	88 MB	40 MB	48 MB	 45%
+ 2	88 MB	60 MB	28 MB	 67%
+ 3	88 MB	36 MB	52 MB	 40%
+Total	443 MB	200 MB	243 MB	 45%
+
+Total virtual image size	100 MB
+using backend plain store
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      1 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:100]
+Id	Size	Used	Avail	Use%
+ 0	178 MB	64 MB	114 MB	 35%
+ 1	88 MB	40 MB	48 MB	 45%
+ 2	88 MB	60 MB	28 MB	 67%
+ 3	88 MB	36 MB	52 MB	 40%
+Total	443 MB	200 MB	243 MB	 45%
+
+Total virtual image size	100 MB
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      2 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:90]
+DATE      1 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:100]
+Id	Size	Used	Avail	Use%
+ 0	178 MB	64 MB	114 MB	 35%
+ 1	88 MB	40 MB	48 MB	 45%
+ 2	88 MB	60 MB	28 MB	 67%
+ 3	88 MB	36 MB	52 MB	 40%
+Total	443 MB	200 MB	243 MB	 45%
+
+Total virtual image size	100 MB
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      3 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:80]
+DATE      2 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:90]
+DATE      1 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:100]
+Id	Size	Used	Avail	Use%
+ 0	178 MB	64 MB	114 MB	 35%
+ 1	88 MB	40 MB	48 MB	 45%
+ 2	88 MB	60 MB	28 MB	 67%
+ 3	88 MB	36 MB	52 MB	 40%
+Total	443 MB	200 MB	243 MB	 45%
+
+Total virtual image size	100 MB
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      4 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:70]
+DATE      3 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:80]
+DATE      2 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:90]
+DATE      1 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:100]
+Id	Size	Used	Avail	Use%
+ 0	178 MB	64 MB	114 MB	 35%
+ 1	88 MB	40 MB	48 MB	 45%
+ 2	88 MB	60 MB	28 MB	 67%
+ 3	88 MB	36 MB	52 MB	 40%
+Total	443 MB	200 MB	243 MB	 45%
+
+Total virtual image size	100 MB
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      5 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:60]
+DATE      4 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:70]
+DATE      3 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:80]
+DATE      2 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:90]
+DATE      1 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:100]
+Id	Size	Used	Avail	Use%
+ 0	178 MB	68 MB	110 MB	 38%
+ 1	88 MB	44 MB	44 MB	 49%
+ 2	88 MB	60 MB	28 MB	 67%
+ 3	88 MB	28 MB	60 MB	 31%
+Total	443 MB	200 MB	243 MB	 45%
+
+Total virtual image size	100 MB
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      6 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:50]
+DATE      5 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:60]
+DATE      4 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:70]
+DATE      3 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:80]
+DATE      2 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:90]
+DATE      1 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:100]
+Id	Size	Used	Avail	Use%
+ 0	178 MB	68 MB	110 MB	 38%
+ 1	88 MB	44 MB	44 MB	 49%
+ 2	88 MB	60 MB	28 MB	 67%
+ 3	88 MB	28 MB	60 MB	 31%
+Total	443 MB	200 MB	243 MB	 45%
+
+Total virtual image size	100 MB
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      7 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:40]
+DATE      6 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:50]
+DATE      5 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:60]
+DATE      4 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:70]
+DATE      3 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:80]
+DATE      2 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:90]
+DATE      1 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:100]
+Id	Size	Used	Avail	Use%
+ 0	178 MB	68 MB	110 MB	 38%
+ 1	88 MB	44 MB	44 MB	 49%
+ 2	88 MB	64 MB	24 MB	 72%
+ 3	88 MB	24 MB	64 MB	 27%
+Total	443 MB	200 MB	243 MB	 45%
+
+Total virtual image size	100 MB
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      8 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:30]
+DATE      7 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:40]
+DATE      6 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:50]
+DATE      5 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:60]
+DATE      4 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:70]
+DATE      3 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:80]
+DATE      2 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:90]
+DATE      1 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:100]
+Id	Size	Used	Avail	Use%
+ 0	178 MB	68 MB	110 MB	 38%
+ 1	88 MB	48 MB	40 MB	 54%
+ 2	88 MB	64 MB	24 MB	 72%
+ 3	88 MB	20 MB	68 MB	 22%
+Total	443 MB	200 MB	243 MB	 45%
+
+Total virtual image size	100 MB
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE      9 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:20]
+DATE      8 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:30]
+DATE      7 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:40]
+DATE      6 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:50]
+DATE      5 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:60]
+DATE      4 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:70]
+DATE      3 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:80]
+DATE      2 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:90]
+DATE      1 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:100]
+Id	Size	Used	Avail	Use%
+ 0	178 MB	76 MB	102 MB	 42%
+ 1	88 MB	48 MB	40 MB	 54%
+ 2	88 MB	64 MB	24 MB	 72%
+ 3	88 MB	12 MB	76 MB	 13%
+Total	443 MB	200 MB	243 MB	 45%
+
+Total virtual image size	100 MB
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE     10 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:10]
+DATE      9 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:20]
+DATE      8 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:30]
+DATE      7 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:40]
+DATE      6 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:50]
+DATE      5 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:60]
+DATE      4 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:70]
+DATE      3 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:80]
+DATE      2 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:90]
+DATE      1 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:100]
+Id	Size	Used	Avail	Use%
+ 0	178 MB	80 MB	98 MB	 44%
+ 1	88 MB	48 MB	40 MB	 54%
+ 2	88 MB	72 MB	16 MB	 81%
+ 3	88 MB	0.0 MB	88 MB	  0%
+Total	443 MB	200 MB	243 MB	 45%
+
+Total virtual image size	100 MB
+Cluster status: running, auto-recovery enabled
+Cluster store: plain with 2 redundancy policy
+Cluster vnodes strategy: fixed
+Cluster vnode mode: node
+Cluster created at DATE
+
+Epoch Time           Version [Host:Port:V-Nodes,,,]
+DATE     11 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100]
+DATE     10 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:10]
+DATE      9 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:20]
+DATE      8 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:30]
+DATE      7 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:40]
+DATE      6 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:50]
+DATE      5 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:60]
+DATE      4 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:70]
+DATE      3 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:80]
+DATE      2 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:90]
+DATE      1 [127.0.0.1:7000:200, 127.0.0.1:7001:100, 127.0.0.1:7002:100, 127.0.0.1:7003:100]
+Id	Size	Used	Avail	Use%
+ 0	178 MB	80 MB	98 MB	 44%
+ 1	88 MB	48 MB	40 MB	 54%
+ 2	88 MB	72 MB	16 MB	 81%
+Total	355 MB	200 MB	155 MB	 56%
+
+Total virtual image size	100 MB

--- a/tests/functional/group
+++ b/tests/functional/group
@@ -119,3 +119,4 @@
 109 auto quick
 110 auto quick
 111 auto quick dog
+112 auto dog

--- a/tests/functional/group
+++ b/tests/functional/group
@@ -120,3 +120,4 @@
 110 auto quick
 111 auto quick dog
 112 auto dog
+113 auto dog


### PR DESCRIPTION
This PR adds two functional tests for regression testing. The 112 checks join, leave, format and shutdown. The 113 checks reweight, and step-by-step join and leave.

This is test-only PR. I'll merge it if Travis CI has passed.

Signed-off-by: Takashi Menjo &lt;menjo.takashi@lab.ntt.co.jp&gt;