### PR TITLE
sheep: Check shared lock state even if VDI is snapshot

### DIFF
--- a/sheep/vdi.c
+++ b/sheep/vdi.c
@@ -883,9 +883,6 @@ worker_fn bool is_refresh_required(uint32_t vid)
 		goto out;
 	}
 
-	if (entry->snapshot)
-		goto out;
-
 	if (entry->lock_state != LOCK_STATE_SHARED)
 		goto out;
 
@@ -920,9 +917,6 @@ worker_fn void validate_myself(uint32_t vid)
 		sd_alert("VID: %"PRIx32" doesn't exist", vid);
 		goto out;
 	}
-
-	if (entry->snapshot)
-		goto out;
 
 	if (entry->lock_state != LOCK_STATE_SHARED)
 		goto out;


### PR DESCRIPTION
This is for iSCSI multipath usage with tgtd.

When sheep receives SD_READ_OBJ request from tgtd, the function is_refresh_required is called. When it returns true, the tgtd reloads the inode object of the target VDI.

In the current sheep implementation, is_refresh_required returns false if the target VDI is snapshot. This lets tgtd not reload the inode object then leads to inode inconsistency between tgtd when all of the following conditions are met:

  * iSCSI multipath is configured (1-active and N-standby)
  * a non-snapshot VDI is set as a new LUN of tgtd
  * a snapshot of the VDI above is taken
  * active path switched after the snapshot is taken
  * tgtd sends SD_READ_OBJ after the active path switched

Also, the function validate_myself has a similar issue.

This PR fixed the problems described above. After the fix, sheep treats snapshot and non-snapshot VDI in the same way i.e. checks its shared lock state.

Signed-off-by: Takashi Menjo &lt;menjo.takashi@lab.ntt.co.jp&gt;