### PR TITLE
dog: Refine output of "dog vdi lock list"

### DIFF
--- a/tests/functional/097.out
+++ b/tests/functional/097.out
@@ -1,7 +1,7 @@
 QA output created by 097
 using backend plain store
-VDI | owner node
-test | IPv4 ip:127.0.0.1 port:7000(shared) IPv4 ip:127.0.0.1 port:7001(shared)
+  Name         Id  VDI id  Tag            Owner node(s)
+  test          0  7c2b25                 IPv4 ip:127.0.0.1 port:7000(shared) IPv4 ip:127.0.0.1 port:7001(shared)
 Try `iscsiadm --help' for more information.
 127.0.0.1:3260,1 iqn.2014-06.org.sheepdog-project
 127.0.0.1:3261,1 iqn.2014-06.org.sheepdog-project


### PR DESCRIPTION
Previously, `dog vdi lock list` outputs only VDIs' name and owner node(s). However, this is not enough because not only working VDIs but also snapshot ones can be locked.

This commit adds VDIs' snapid, id and tag columns to output of `dog vdi lock list`, like `dog vdi list`. After this, its output is like below:

```
  Name         Id  VDI id  Tag            Owner node(s)
s foovdi        1  270cf4  foo1           [..]
  foovdi        0  270cf5                 [..]
c hoge          0  8c7d08                 [..]
```

Note that raw output mode is not supported yet.

Fix #126.

Signed-off-by: Takashi Menjo &lt;menjo.takashi@lab.ntt.co.jp&gt;