### PR TITLE
SystemD doesn't listen to ulimit

### DIFF
--- a/script/sheepdog.service.in
+++ b/script/sheepdog.service.in
@@ -7,12 +7,13 @@ Wants=syslog.target
 EnvironmentFile=-@SYSCONFDIR@/conf.d/sheepdog.conf
 EnvironmentFile=-@SYSCONFDIR@/sysconfig/sheepdog
 EnvironmentFile=-@SYSCONFDIR@/default/sheepdog
-ExecStart=/bin/sh -c 'ulimit -n 32768; @SBINDIR@/sheep --pidfile @LOCALSTATEDIR@/run/sheep.pid $(if [ -z "$SHEEP_OPTS" ]; then echo "--cluster local --log dst=syslog --upgrade @LOCALSTATEDIR@/lib/sheepdog"; else echo $SHEEP_OPTS; fi)'
+ExecStart=/bin/sh -c '@SBINDIR@/sheep --pidfile @LOCALSTATEDIR@/run/sheep.pid $(if [ -z "$SHEEP_OPTS" ]; then echo "--cluster local --log dst=syslog --upgrade @LOCALSTATEDIR@/lib/sheepdog"; else echo $SHEEP_OPTS; fi)'
 PIDFile=@LOCALSTATEDIR@/run/sheep.pid
 Type=forking
-Restart=on-abort
+Restart=on-failure
 StartLimitInterval=10s
 StartLimitBurst=3
+LimitNOFILE=32768
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
SystemD doesn't listen to anyone's ulimit methods. It forces the daemon and it's children to 1024. There is a complex way of allocating more resources to a 'slice' using additional SystemD files but I've found that "LimitNOFILE" works as well after a reboot of the entire system, not just a daemon-reload or service restart.

Also, when Sheepdog 'crashes', the signal doesn't propagate through /bin/sh (the method to which you are starting Sheepdog) so SystemD only 'sees' a non-zero exit code. On-abort only handles unclean signals, on-failure handles both signals and exit codes. This restarts the sheepdog daemon automatically if it 'fails'. 