### PR TITLE
lib/util: Fix xrealloc to check out of memory error correctly

### DIFF
--- a/lib/util.c
+++ b/lib/util.c
@@ -43,8 +43,9 @@ void *xzalloc(size_t size)
 
 void *xrealloc(void *ptr, size_t size)
 {
+	errno = 0;
 	void *ret = realloc(ptr, size);
-	if (unlikely(!ret))
+	if (unlikely(errno == ENOMEM))
 		panic("Out of memory");
 	return ret;
 }


### PR DESCRIPTION
The present xrealloc panics as &quot;Out of memory&quot; if realloc returns NULL. However, man page of realloc[1] says that &quot;If size was equal to 0, either NULL or a pointer suitable to be passed to free() is returned.&quot; So xrealloc can panic wrongly when size is equal to 0 and realloc returns NULL.

This commit fixes the issue described above. The man page also says that &quot;The UNIX 98 standard requires [..] realloc() to set errno to ENOMEM upon failure.&quot; So I evaluate errno instead of returned value to check whether out of memory really occurred or not.

[1] http://linux.die.net/man/3/realloc

Signed-off-by: Takashi Menjo &lt;menjo.takashi@lab.ntt.co.jp&gt;