### PR TITLE
tests: clean *.info files individually to avoid making submodules dirty

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -39,7 +39,7 @@ dist-clean-local:
 clean-generic:
 	rm -rf $(SPEC) $(TARFILE) cscope*
 	find -name '*.orig' -or -name '*.rej' | xargs rm -f
-	find -name '*.gcno' -or -name '*.gcda' -or -name '*.info' | xargs rm -f
+	find -name '*.gcno' -or -name '*.gcda' | xargs rm -f
 
 cscope:
 	@echo create cscope.out

--- a/tests/unit/dog/Makefile.am
+++ b/tests/unit/dog/Makefile.am
@@ -17,7 +17,7 @@ test_common_SOURCES	= test_common.c mock_dog.c			\
 			  dog/common.c
 
 clean-local:
-	rm -f ${check_PROGRAMS} *.o
+	rm -f ${check_PROGRAMS} *.o dog.info
 
 coverage:
 	@lcov -d . -c -o dog.info

--- a/tests/unit/lib/Makefile.am
+++ b/tests/unit/lib/Makefile.am
@@ -36,7 +36,7 @@ test_atomic_create_and_write_SOURCES =					\
 			  ../cmock/src/cmock.c ../unity/src/unity.c
 
 clean-local:
-	rm -f ${check_PROGRAMS} *.o sheep.info
+	rm -f ${check_PROGRAMS} *.o lib.info
 
 coverage:
-	@lcov -d . -c -o sheep.info
+	@lcov -d . -c -o lib.info

--- a/tests/unit/lib/Makefile.am
+++ b/tests/unit/lib/Makefile.am
@@ -36,7 +36,7 @@ test_atomic_create_and_write_SOURCES =					\
 			  ../cmock/src/cmock.c ../unity/src/unity.c
 
 clean-local:
-	rm -f ${check_PROGRAMS} *.o
+	rm -f ${check_PROGRAMS} *.o sheep.info
 
 coverage:
 	@lcov -d . -c -o sheep.info

--- a/tests/unit/sheep/Makefile.am
+++ b/tests/unit/sheep/Makefile.am
@@ -64,7 +64,7 @@ test_recovery_SOURCES   = test_recovery.c ../../../sheep/recovery.c \
                 ../cmock/src/cmock.c ../unity/src/unity.c
 
 clean-local:
-	rm -f ${check_PROGRAMS} *.o
+	rm -f ${check_PROGRAMS} *.o sheep.info
 
 coverage:
 	@lcov -d . -c -o sheep.info


### PR DESCRIPTION
There are *.info files under submodules. They are not for coverage report but deleted by 'make clean'. This PR fixes the issue above.

This PR also renames coverage report file for lib to 'lib.info'. That should not be 'sheep.info'.

Fix #324.