### PR TITLE
sheep: remove object list cache of ledger when removed from store

### DIFF
--- a/sheep/ops.c
+++ b/sheep/ops.c
@@ -1194,6 +1194,7 @@ int peer_decref_object(struct request *req)
 
 		/* reclaim object */
 		if (exist) {
+			objlist_cache_remove(ledger_oid);
 			ret = sd_store->remove_object(ledger_oid, -1);
 			if (ret != SD_RES_SUCCESS) {
 				sd_err("error %s", sd_strerror(ret));


### PR DESCRIPTION
Each object list cache should be removed when it is removed from object store. Inode and data ones are done so by peer_remove_obj. However, ledger objects are not so by peer_decref_object, and remaining cache leads to unnecessary recovery trial and error log.

This commit lets sheep remove object list cache of ledger when it is removed from store.

Fix #341