### PR TITLE
zk_control: fix "purge" threshold and default behavior

### DIFF
--- a/tools/zk_control.c
+++ b/tools/zk_control.c
@@ -24,7 +24,7 @@
 #define DEFAULT_BASE "/sheepdog"
 #define QUEUE_ZNODE "/queue"
 #define QUEUE_POS_ZNODE "/queue_pos"
-#define MIN_THRESHOLD 86400
+#define DEFAULT_THRESHOLD 86400L
 
 #define FOR_EACH_ZNODE(parent, path, strs)			       \
 	for ((strs)->data += (strs)->count;			       \
@@ -307,27 +307,26 @@ err:
 static int do_purge(int argc, char **argv)
 {
 	struct String_vector strs;
-	int rc, len, threshold, deleted = 0;
+	int rc, len, deleted = 0;
+	long threshold = DEFAULT_THRESHOLD;
 	char *p, path[256];
 	struct zk_event ev;
 	struct Stat stat;
 	struct timeval tv;
 
-	if (argc != 3) {
-		fprintf(stderr, "remove queue: need specify "
-				"threshold in seconds\n");
-		return -1;
-	}
-
-	threshold = strtol(argv[2], &p, 10);
-	if (p == argv[2]) {
-		fprintf(stderr, "threshold must be a number\n");
-		return -1;
-	}
-	if (threshold < MIN_THRESHOLD) {
-		threshold = MIN_THRESHOLD;
-		fprintf(stdout, "threshold is less than %d seconds, "
-			"set it to %d\n", MIN_THRESHOLD, MIN_THRESHOLD);
+	if (argc < 3) {
+		fprintf(stderr, "threshold not given; use default %ld\n",
+		        threshold);
+	} else {
+		threshold = strtol(argv[2], &p, 10);
+		if (*p != '\0' || threshold < 0L) {
+			fprintf(stderr,
+			        "threshold must be a non-negative number\n");
+			return -1;
+		} else if (errno == ERANGE) {
+			fprintf(stderr, "threshold too large\n");
+			return -1;
+		}
 	}
 
 	gettimeofday(&tv, NULL);


### PR DESCRIPTION
Now zk_control purge ...
* can purge znodes created within last 24 hours
* purges znode created before more than 24 hours by default i.e. when threshold is not given explicitly
* returns error when threshold is negative value (bug fix)

Signed-off-by: Takashi Menjo &lt;menjo.takashi@lab.ntt.co.jp&gt;