### PR TITLE
zk_control: Log exact number of deleted nodes when purge is failed

### DIFF
--- a/tools/zk_control.c
+++ b/tools/zk_control.c
@@ -367,6 +367,9 @@ static int do_purge(int argc, char **argv)
 	fprintf(stdout, "completed. %d queue nodes are deleted\n", deleted);
 	return 0;
 err:
+	if (deleted > 0) {
+		fprintf(stderr, "%d queue nodes are deleted, but ", deleted);
+	}
 	fprintf(stderr, "failed to purge %s, %s\n", QUEUE_ZNODE, zerror(rc));
 	return -1;
 }


### PR DESCRIPTION
Current zk_control implementaion don't show a resulted number of deleted nodes when purge is failed.
This patch is to show a resulted deleted number of nodes on stderr.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>