### PR TITLE
sheep: add a new option for setting threads for dynamic workqueues

### DIFF
--- a/include/work.h
+++ b/include/work.h
@@ -66,6 +66,7 @@ struct work_queue *create_fixed_work_queue(const char *name, int nr_threads);
 void queue_work(struct work_queue *q, struct work *work);
 bool work_queue_empty(struct work_queue *q);
 int wq_trace_init(void);
+void set_max_dynamic_threads(size_t nr_max);
 
 #ifdef HAVE_TRACE
 void suspend_worker_threads(void);

--- a/sheep/sheep.c
+++ b/sheep/sheep.c
@@ -155,6 +155,8 @@ static struct sd_option sheep_options[] = {
 	{'V', "vnodes", true, "set number of vnodes", vnodes_help},
 	{'w', "wq-threads", true, "specify a number of threads for workqueue"},
 	{'W', "wildcard-recovery", false, "wildcard recovery for first time"},
+	{'x', "max-dynamic-threads", true,
+	 "specify the maximum number of threads for dynamic workqueue"},
 	{'y', "myaddr", true, "specify the address advertised to other sheep",
 	 myaddr_help},
 	{'z', "zone", true,
@@ -703,6 +705,7 @@ int main(int argc, char **argv)
 	bool daemonize = true;
 	int32_t nr_vnodes = -1;
 	int64_t zone = -1;
+	uint32_t max_dynamic_threads = 0;
 	struct cluster_driver *cdrv;
 	struct option *long_options;
 #ifdef HAVE_HTTP
@@ -878,6 +881,16 @@ int main(int argc, char **argv)
 		case 'w':
 			if (option_parse(optarg, ",", wq_parsers) < 0)
 				exit(1);
+			break;
+		case 'x':
+			max_dynamic_threads = str_to_u32(optarg);
+			if (errno != 0 || max_dynamic_threads < 1) {
+				sd_err("Invalid number of threads '%s': "
+				       "must be an integer between 1 and %"PRIu32,
+				       optarg, UINT32_MAX);
+				exit(1);
+			}
+			set_max_dynamic_threads((size_t)max_dynamic_threads);
 			break;
 		default:
 			usage(1);


### PR DESCRIPTION
This PR adds a new option **-x** to sheep for configuring the maximum number of threads for dynamic workqueues.

Example:

```
# Set the max number of threads for dynamic workqueues to 500
$ sheep -x 500
```

If this is not passed, sheep uses a default formula for configuring the maximum number (that is, *max(#nodes,#cores,16)\*2*).

This is for tuning performance, so please be careful to use. Sheep works very slowly if you give a too small number, or may be shot by OOM-killer under heavy load if you give a huge number.

-----

This also makes a minor change on "doubling growth". If the double of the current number of threads for a dynamic queue exceeds the maximum number, that workqueue grows into that maximum number.

-----

Signed-off-by: Takashi Menjo &lt;menjo.takashi@lab.ntt.co.jp&gt;
