### PR TITLE
Print object ID in '"%016" PRIx64'

### DIFF
--- a/dog/benchmark.c
+++ b/dog/benchmark.c
@@ -69,7 +69,7 @@ static void benchmark_io_worker(struct work *work)
 			       io_work->offset, 0, io_work->nr_copies,
 			       io_work->copy_policy, false, false);
 	if (ret != SD_RES_SUCCESS) {
-		sd_err("failed to write object %"PRIx64", %s",
+		sd_err("failed to write object %016"PRIx64", %s",
 		       oid, sd_strerror(ret));
 		exit(1);
 	}

--- a/dog/common.c
+++ b/dog/common.c
@@ -97,12 +97,12 @@ int dog_read_object(uint64_t oid, void *data, unsigned int datalen,
 
 	ret = dog_exec_req(&sd_nid, &hdr, data);
 	if (ret < 0) {
-		sd_err("Failed to read object %" PRIx64, oid);
+		sd_err("Failed to read object %016" PRIx64, oid);
 		return SD_RES_EIO;
 	}
 
 	if (rsp->result != SD_RES_SUCCESS) {
-		sd_err("Failed to read object %" PRIx64 " %s", oid,
+		sd_err("Failed to read object %016" PRIx64 " %s", oid,
 		       sd_strerror(rsp->result));
 		return rsp->result;
 	}
@@ -139,11 +139,11 @@ int dog_write_object(uint64_t oid, uint64_t cow_oid, void *data,
 
 	ret = dog_exec_req(&sd_nid, &hdr, data);
 	if (ret < 0) {
-		sd_err("Failed to write object %" PRIx64, oid);
+		sd_err("Failed to write object %016" PRIx64, oid);
 		return SD_RES_EIO;
 	}
 	if (rsp->result != SD_RES_SUCCESS) {
-		sd_err("Failed to write object %" PRIx64 ": %s", oid,
+		sd_err("Failed to write object %016" PRIx64 ": %s", oid,
 		       sd_strerror(rsp->result));
 		return rsp->result;
 	}

--- a/dog/farm/farm.c
+++ b/dog/farm/farm.c
@@ -279,7 +279,7 @@ static void do_save_object(struct work *work)
 	return;
 error:
 	free(buf);
-	sd_err("Fail to save object, oid %"PRIx64, sw->entry.oid);
+	sd_err("Fail to save object, oid %016"PRIx64, sw->entry.oid);
 	uatomic_set_true(&work_error);
 }
 
@@ -437,7 +437,7 @@ static void do_load_object(struct work *work)
 	return;
 error:
 	free(buffer);
-	sd_err("Fail to load object, oid %"PRIx64, sw->entry.oid);
+	sd_err("Fail to load object, oid %016"PRIx64, sw->entry.oid);
 	uatomic_set_true(&work_error);
 }
 
@@ -489,7 +489,7 @@ static int visit_vdi_obj_entry(struct trunk_entry *entry, void *data)
 
 	inode = slice_read(entry->sha1, &size);
 	if (!inode) {
-		sd_err("Fail to load vdi object, oid %"PRIx64, entry->oid);
+		sd_err("Fail to load vdi object, oid %016"PRIx64, entry->oid);
 		goto out;
 	}
 

--- a/dog/farm/object_tree.c
+++ b/dog/farm/object_tree.c
@@ -72,7 +72,7 @@ void object_tree_print(void)
 	printf("nr_objs: %d\n", tree.nr_objs);
 
 	rb_for_each_entry(entry, &tree.root, node)
-		printf("Obj id: %"PRIx64"\n", entry->oid);
+		printf("Obj id: %016"PRIx64"\n", entry->oid);
 }
 
 void object_tree_free(void)

--- a/dog/vdi.c
+++ b/dog/vdi.c
@@ -1014,7 +1014,7 @@ static int do_vdi_delete(const char *vdiname, int snap_id, const char *snap_tag)
 	ret = dog_read_object(vid_to_vdi_oid(vid), inode, sizeof(*inode),
 			      0, false);
 	if (ret) {
-		sd_err("failed to read inode object: %"PRIx64,
+		sd_err("failed to read inode object: %016"PRIx64,
 		       vid_to_vdi_oid(vid));
 		ret = EXIT_FAILURE;
 		goto out;
@@ -1047,7 +1047,7 @@ static int do_vdi_delete(const char *vdiname, int snap_id, const char *snap_tag)
 				       false, true);
 		if (ret) {
 			sd_err("failed to update inode for discarding objects:"
-			       " %"PRIx64, vid_to_vdi_oid(vid));
+			       " %016"PRIx64, vid_to_vdi_oid(vid));
 			ret = EXIT_FAILURE;
 			goto out;
 		}
@@ -1226,7 +1226,7 @@ static int vdi_object_location(int argc, char **argv)
 	vdi_id = sd_inode_get_vid(inode, idx);
 	oid = vid_to_data_oid(vdi_id, idx);
 	if (vdi_id) {
-		printf("Looking for the object 0x%" PRIx64
+		printf("Looking for the object %016" PRIx64
 		       " (vid 0x%" PRIx32 " idx %"PRIu64
 		       ", %u copies) with %d nodes\n\n",
 			oid, vid, idx, inode->nr_copies, sd_nodes_nr);
@@ -1388,7 +1388,7 @@ retry:
 		struct rb_root nroot = RB_ROOT;
 
 		log = (struct epoch_log *)next_log;
-		printf("\nobj %"PRIx64" locations at epoch %d, copies = %d\n",
+		printf("\nobj %016"PRIx64" locations at epoch %d, copies = %d\n",
 		       oid, log->epoch, nr_copies);
 		printf("---------------------------------------------------\n");
 
@@ -1464,11 +1464,11 @@ static int vdi_track(int argc, char **argv)
 		vdi_id = sd_inode_get_vid(inode, idx);
 		oid = vid_to_data_oid(vdi_id, idx);
 
-		printf("Tracking the object 0x%" PRIx64
+		printf("Tracking the object %016" PRIx64
 		       " (the inode vid 0x%" PRIx32 " idx %u)"
 		       " with %d nodes\n", oid, vid, idx, sd_nodes_nr);
 	} else
-		printf("Tracking the object 0x%" PRIx64
+		printf("Tracking the object %016" PRIx64
 		       " (the inode vid 0x%" PRIx32 ")"
 		       " with %d nodes\n", oid, vid, sd_nodes_nr);
 
@@ -1840,7 +1840,7 @@ static void write_object_to(const struct sd_vnode *vnode, uint64_t oid,
 		exit(EXIT_SYSFAIL);
 
 	if (rsp->result != SD_RES_SUCCESS) {
-		sd_err("FATAL: failed to write %"PRIx64", %s", oid,
+		sd_err("FATAL: failed to write %016"PRIx64", %s", oid,
 		       sd_strerror(rsp->result));
 		exit(EXIT_FAILURE);
 	}
@@ -1921,9 +1921,9 @@ static void vdi_repair_main(struct work *work)
 	struct vdi_check_info *info = vcw->info;
 
 	if (vcw->object_found)
-		fprintf(stdout, "fixed replica %"PRIx64"\n", info->oid);
+		fprintf(stdout, "fixed replica %016"PRIx64"\n", info->oid);
 	else
-		fprintf(stdout, "fixed missing %"PRIx64"\n", info->oid);
+		fprintf(stdout, "fixed missing %016"PRIx64"\n", info->oid);
 
 	info->refcnt--;
 	if (info->refcnt == 0)
@@ -1966,7 +1966,7 @@ static void vdi_check_object_work(struct work *work)
 		vcw->object_found = false;
 		break;
 	default:
-		sd_err("failed to read %" PRIx64 " from %s, %s", info->oid,
+		sd_err("failed to read %016" PRIx64 " from %s, %s", info->oid,
 		       addr_to_str(vcw->vnode->node->nid.addr,
 				   vcw->vnode->node->nid.port),
 		       sd_strerror(rsp->result));
@@ -1979,10 +1979,10 @@ static void check_replicatoin_object(struct vdi_check_info *info)
 	if (info->majority == NULL) {
 		switch (info->result) {
 		case VDI_CHECK_NO_OBJ_FOUND:
-			sd_err("no node has %" PRIx64, info->oid);
+			sd_err("no node has %016" PRIx64, info->oid);
 			break;
 		case VDI_CHECK_NO_MAJORITY_FOUND:
-			sd_err("no majority of %" PRIx64, info->oid);
+			sd_err("no majority of %016" PRIx64, info->oid);
 			break;
 		default:
 			sd_err("unknown result of vdi check: %d", info->result);
@@ -2048,12 +2048,12 @@ static void check_erasure_object(struct vdi_check_info *info)
 					 object_size);
 			if (memcmp(obj, info->vcw[d + k].buf, len) != 0) {
 				/* TODO repair the inconsistency */
-				sd_err("object %"PRIx64" is inconsistent", oid);
+				sd_err("object %016"PRIx64" is inconsistent", oid);
 				goto out;
 			}
 		}
 	} else if (j > p) {
-		sd_err("failed to rebuild object %"PRIx64". %d copies get "
+		sd_err("failed to rebuild object %016"PRIx64". %d copies get "
 		       "lost, more than %d", oid, j, p);
 		goto out;
 	} else {
@@ -2067,7 +2067,7 @@ static void check_erasure_object(struct vdi_check_info *info)
 					 object_size);
 			write_object_to(info->vcw[m].vnode, oid, obj,
 					len, true, info->vcw[m].ec_index);
-			fprintf(stdout, "fixed missing %"PRIx64", "
+			fprintf(stdout, "fixed missing %016"PRIx64", "
 				"copy index %d\n", info->oid, m);
 		}
 	}

--- a/lib/sd_inode.c
+++ b/lib/sd_inode.c
@@ -167,7 +167,7 @@ static void traverse_btree(const struct sd_inode *inode, btree_cb_fn fn,
 			ret = inode_actor.reader(iter_idx->oid, &tmp,
 						 SD_INODE_DATA_INDEX_SIZE, 0);
 			if (ret != SD_RES_SUCCESS) {
-				sd_err("failed to read %"PRIx64, iter_idx->oid);
+				sd_err("failed to read %016"PRIx64, iter_idx->oid);
 				iter_idx++;
 				continue;
 			}
@@ -517,7 +517,7 @@ static int search_whole_btree(read_node_fn reader, const struct sd_inode *inode,
 								 idx);
 				path->p_index_header = leaf_node;
 			} else {
-				sd_debug("last ext-node is full (oid: %"
+				sd_debug("last ext-node is full (oid: %016"
 					 PRIx64")", oid);
 				free(leaf_node);
 			}

--- a/sheep/gateway.c
+++ b/sheep/gateway.c
@@ -39,7 +39,7 @@ static struct req_iter *prepare_replication_requests(struct request *req,
 	uint64_t off = req->rq.obj.offset;
 	struct req_iter *reqs;
 
-	sd_debug("%"PRIx64, req->rq.obj.oid);
+	sd_debug("%016"PRIx64, req->rq.obj.oid);
 
 	reqs = zalloc(sizeof(*reqs) * nr_copies);
 	if(unlikely(!reqs))
@@ -149,7 +149,7 @@ static struct req_iter *prepare_erasure_requests(struct request *req, int *nr)
 
 		reqs[i].buf = malloc(l);
 		if(!reqs[i].buf) {
-			sd_err("failed to init request buffer %"PRIx64,
+			sd_err("failed to init request buffer %016"PRIx64,
 			       req->rq.obj.oid);
 			for(j = 0; j < i; j++)
 				free(reqs[j].buf);
@@ -173,7 +173,7 @@ static struct req_iter *prepare_erasure_requests(struct request *req, int *nr)
 
 	p = buf = init_erasure_buffer(req, SD_EC_DATA_STRIPE_SIZE * nr_stripe);
 	if (!buf) {
-		sd_err("failed to init erasure buffer %"PRIx64,
+		sd_err("failed to init erasure buffer %016"PRIx64,
 		       req->rq.obj.oid);
 		for (i = 0; i < nr_to_send; i++)
 			free(reqs[i].buf);
@@ -297,7 +297,7 @@ static int gateway_replication_read(struct request *req)
 		if (ret == SD_RES_SUCCESS)
 			goto out;
 
-		sd_err("local read %"PRIx64" failed, %s", oid,
+		sd_err("local read %016"PRIx64" failed, %s", oid,
 		       sd_strerror(ret));
 		break;
 	}
@@ -466,7 +466,7 @@ again:
 		}
 		ret = rsp->result;
 		if (ret != SD_RES_SUCCESS) {
-			sd_err("fail %"PRIx64", %s", req->rq.obj.oid,
+			sd_err("fail %016"PRIx64", %s", req->rq.obj.oid,
 			       sd_strerror(ret));
 			err_ret = ret;
 		}
@@ -519,7 +519,7 @@ static int gateway_forward_request(struct request *req)
 	struct forward_info fi;
 #endif
 
-	sd_debug("%"PRIx64, oid);
+	sd_debug("%016"PRIx64, oid);
 
 	gateway_init_fwd_hdr(&hdr, &req->rq);
 	oid_to_nodes(oid, &req->vinfo->vroot, nr_copies, target_nodes);
@@ -662,7 +662,7 @@ static int prepare_obj_refcnt(const struct sd_req *hdr, uint32_t *vids,
 			     nr_vids * sizeof(vids[0]),
 			     offsetof(struct sd_inode, data_vdi_id[start]));
 	if (ret != SD_RES_SUCCESS) {
-		sd_err("failed to read vdi, %" PRIx64, hdr->obj.oid);
+		sd_err("failed to read vdi, %016" PRIx64, hdr->obj.oid);
 		return ret;
 	}
 
@@ -670,7 +670,7 @@ static int prepare_obj_refcnt(const struct sd_req *hdr, uint32_t *vids,
 			     nr_vids * sizeof(refs[0]),
 			     offsetof(struct sd_inode, gref[start]));
 	if (ret != SD_RES_SUCCESS) {
-		sd_err("failed to read vdi, %" PRIx64, hdr->obj.oid);
+		sd_err("failed to read vdi, %016" PRIx64, hdr->obj.oid);
 		return ret;
 	}
 
@@ -724,7 +724,7 @@ int gateway_read_obj(struct request *req)
 	if ((req->rq.flags & SD_FLAG_CMD_TGT) &&
 	    !is_inode_refresh_req(req) &&
 	    is_refresh_required(oid_to_vid(oid))) {
-		sd_debug("refresh is required: %"PRIx64, oid);
+		sd_debug("refresh is required: %016"PRIx64, oid);
 		return SD_RES_INODE_INVALIDATED;
 	}
 
@@ -790,7 +790,7 @@ int gateway_write_obj(struct request *req)
 
 	if ((req->rq.flags & SD_FLAG_CMD_TGT) &&
 	    is_refresh_required(oid_to_vid(oid))) {
-		sd_debug("refresh is required: %"PRIx64, oid);
+		sd_debug("refresh is required: %016"PRIx64, oid);
 		return SD_RES_INODE_INVALIDATED;
 	}
 
@@ -835,14 +835,14 @@ int gateway_write_obj(struct request *req)
 			- offsetof(struct sd_inode, data_vdi_id);
 		start = offset / sizeof(*vids);
 
-		sd_debug("update reference counts, %" PRIx64, hdr->obj.oid);
+		sd_debug("update reference counts, %016" PRIx64, hdr->obj.oid);
 
 		ret = sd_write_object(hdr->obj.oid, (char *)zeroed_refs,
 				      nr_vids * sizeof(*zeroed_refs),
 				      offsetof(struct sd_inode, gref)
 				      + start * sizeof(*zeroed_refs), false);
 		if (ret != SD_RES_SUCCESS) {
-			sd_err("updating reference count of inode object %"
+			sd_err("updating reference count of inode object %016"
 			       PRIx64 " failed: %s", hdr->obj.oid,
 			       sd_strerror(ret));
 
@@ -850,7 +850,7 @@ int gateway_write_obj(struct request *req)
 		}
 
 		if (!(sys->cinfo.flags & SD_CLUSTER_FLAG_RECYCLE_VID)) {
-			sd_debug("update ledger objects of %"PRIx64,
+			sd_debug("update ledger objects of %016"PRIx64,
 				 hdr->obj.oid);
 			refcnt_work = zalloc(sizeof(*refcnt_work));
 			if (!refcnt_work)
@@ -943,7 +943,7 @@ int gateway_create_and_write_obj(struct request *req)
 
 	if ((req->rq.flags & SD_FLAG_CMD_TGT) &&
 	    is_refresh_required(oid_to_vid(oid))) {
-		sd_debug("refresh is required: %"PRIx64, oid);
+		sd_debug("refresh is required: %016"PRIx64, oid);
 		return SD_RES_INODE_INVALIDATED;
 	}
 

--- a/sheep/group.c
+++ b/sheep/group.c
@@ -763,7 +763,7 @@ static void cinfo_collection_work(struct work *work)
 			return;
 		}
 
-		panic("this node should have object of inode: %"PRIx64
+		panic("this node should have object of inode: %016"PRIx64
 		      "but doesn't have", vid_to_vdi_oid(w->next_vid));
 	}
 

--- a/sheep/http/kv.c
+++ b/sheep/http/kv.c
@@ -132,7 +132,7 @@ static void bucket_iterater(struct sd_index *idx, void *arg, int ignore)
 	oid = vid_to_data_oid(idx->vdi_id, idx->idx);
 	ret = sd_read_object(oid, (char *)&bnode, sizeof(bnode), 0);
 	if (ret != SD_RES_SUCCESS) {
-		sd_err("Failed to read data object %"PRIx64, oid);
+		sd_err("Failed to read data object %016"PRIx64, oid);
 		return;
 	}
 
@@ -162,7 +162,7 @@ static int read_account_meta(const char *account, uint64_t *bucket_count,
 	inode = xmalloc(sizeof(*inode));
 	ret = sd_read_object(oid, (char *)inode, sizeof(struct sd_inode), 0);
 	if (ret != SD_RES_SUCCESS) {
-		sd_err("Failed to read inode header %"PRIx64, oid);
+		sd_err("Failed to read inode header %016"PRIx64, oid);
 		goto out;
 	}
 
@@ -256,7 +256,7 @@ static int bnode_do_create(struct kv_bnode *bnode, struct sd_inode *inode,
 	bnode->oid = oid;
 	ret = sd_write_object(oid, (char *)bnode, sizeof(*bnode), 0, create);
 	if (ret != SD_RES_SUCCESS) {
-		sd_err("failed to create object, %" PRIx64, oid);
+		sd_err("failed to create object, %016" PRIx64, oid);
 		goto out;
 	}
 	if (!create)
@@ -265,7 +265,7 @@ static int bnode_do_create(struct kv_bnode *bnode, struct sd_inode *inode,
 	sd_inode_set_vid(inode, idx, vid);
 	ret = sd_inode_write_vid(inode, idx, vid, vid, 0, false, false);
 	if (ret != SD_RES_SUCCESS) {
-		sd_err("failed to update inode, %" PRIx64,
+		sd_err("failed to update inode, %016" PRIx64,
 		       vid_to_vdi_oid(vid));
 		goto out;
 	}
@@ -510,7 +510,7 @@ static void object_iterater(struct sd_index *idx, void *arg, int ignore)
 	oid = vid_to_data_oid(idx->vdi_id, idx->idx);
 	ret = sd_read_object(oid, (char *)onode, read_size, 0);
 	if (ret != SD_RES_SUCCESS) {
-		sd_err("Failed to read data object %"PRIx64, oid);
+		sd_err("Failed to read data object %016"PRIx64, oid);
 		goto out;
 	}
 
@@ -696,7 +696,7 @@ static int vdi_read_write(uint32_t vid, char *data, size_t length,
 
 		ret = exec_local_req_async(&hdr, data, iocb);
 		if (ret != SD_RES_SUCCESS)
-			sd_err("failed to write object %" PRIx64 ", %s",
+			sd_err("failed to write object %016" PRIx64 ", %s",
 			       hdr.obj.oid, sd_strerror(ret));
 
 		offset += len;
@@ -895,7 +895,7 @@ static int onode_do_update(struct kv_onode *onode)
 	ret = sd_write_object(onode->oid, (char *)onode, ONODE_HDR_SIZE + len,
 			      0, false);
 	if (ret != SD_RES_SUCCESS)
-		sd_err("Failed to update object, %" PRIx64, onode->oid);
+		sd_err("Failed to update object, %016" PRIx64, onode->oid);
 	return ret;
 }
 
@@ -970,7 +970,7 @@ static int onode_do_create(struct kv_onode *onode, struct sd_inode *inode,
 	ret = sd_write_object(oid, (char *)onode, ONODE_HDR_SIZE + len,
 			      0, create);
 	if (ret != SD_RES_SUCCESS) {
-		sd_err("failed to create object, %" PRIx64, oid);
+		sd_err("failed to create object, %016" PRIx64, oid);
 		goto out;
 	}
 	if (!create)
@@ -979,7 +979,7 @@ static int onode_do_create(struct kv_onode *onode, struct sd_inode *inode,
 	sd_inode_set_vid(inode, idx, vid);
 	ret = sd_inode_write_vid(inode, idx, vid, vid, 0, false, false);
 	if (ret != SD_RES_SUCCESS) {
-		sd_err("failed to update inode, %" PRIx64,
+		sd_err("failed to update inode, %016" PRIx64,
 		       vid_to_vdi_oid(vid));
 		goto out;
 	}

--- a/sheep/http/oalloc.c
+++ b/sheep/http/oalloc.c
@@ -123,7 +123,7 @@ int oalloc_new_prepare(uint32_t vid, uint64_t *start, uint64_t count)
 
 	ret = sd_read_object(oid, meta, SD_DATA_OBJ_SIZE, 0);
 	if (ret != SD_RES_SUCCESS) {
-		sd_err("failed to read meta %" PRIx64 ", %s", oid,
+		sd_err("failed to read meta %016" PRIx64 ", %s", oid,
 		       sd_strerror(ret));
 		goto out;
 	}
@@ -150,7 +150,7 @@ int oalloc_new_prepare(uint32_t vid, uint64_t *start, uint64_t count)
 	/* Update the meta object */
 	ret = sd_write_object(oid, meta, oalloc_meta_length(hd), 0, false);
 	if (ret != SD_RES_SUCCESS)
-		sd_err("failed to update meta %"PRIx64 ", %s", oid,
+		sd_err("failed to update meta %016"PRIx64 ", %s", oid,
 		       sd_strerror(ret));
 out:
 	free(meta);
@@ -172,7 +172,7 @@ int oalloc_new_finish(uint32_t vid, uint64_t start, uint64_t count)
 	ret = sd_read_object(vid_to_vdi_oid(vid), (char *)inode,
 			     sizeof(*inode), 0);
 	if (ret != SD_RES_SUCCESS) {
-		sd_err("failed to read inode, %" PRIx64 ", %s",
+		sd_err("failed to read inode, %016" PRIx64 ", %s",
 		       vid_to_vdi_oid(vid), sd_strerror(ret));
 		goto out;
 	}
@@ -182,7 +182,7 @@ int oalloc_new_finish(uint32_t vid, uint64_t start, uint64_t count)
 
 	ret = sd_inode_write(inode, 0, false, false);
 	if (ret != SD_RES_SUCCESS) {
-		sd_err("failed to update inode, %" PRIx64", %s",
+		sd_err("failed to update inode, %016" PRIx64", %s",
 		       vid_to_vdi_oid(vid), sd_strerror(ret));
 		goto out;
 	}
@@ -270,7 +270,7 @@ int oalloc_free(uint32_t vid, uint64_t start, uint64_t count)
 	ret = sd_read_object(vid_to_vdi_oid(vid), (char *)inode,
 			     sizeof(*inode), 0);
 	if (ret != SD_RES_SUCCESS) {
-		sd_err("failed to read inode, %" PRIx64 ", %s",
+		sd_err("failed to read inode, %016" PRIx64 ", %s",
 		       vid_to_vdi_oid(vid), sd_strerror(ret));
 		goto out;
 	}
@@ -281,14 +281,14 @@ int oalloc_free(uint32_t vid, uint64_t start, uint64_t count)
 
 	ret = sd_inode_write(inode, 0, false, false);
 	if (ret != SD_RES_SUCCESS) {
-		sd_err("failed to update inode, %" PRIx64", %s",
+		sd_err("failed to update inode, %016" PRIx64", %s",
 		       vid_to_vdi_oid(vid), sd_strerror(ret));
 		goto out;
 	}
 
 	ret = sd_read_object(oid, meta, SD_DATA_OBJ_SIZE, 0);
 	if (ret != SD_RES_SUCCESS) {
-		sd_err("failed to read meta %" PRIx64 ", %s", oid,
+		sd_err("failed to read meta %016" PRIx64 ", %s", oid,
 		       sd_strerror(ret));
 		goto out;
 	}
@@ -316,7 +316,7 @@ int oalloc_free(uint32_t vid, uint64_t start, uint64_t count)
 	hd = (struct header *)meta;
 	ret = sd_write_object(oid, meta, oalloc_meta_length(hd), 0, false);
 	if (ret != SD_RES_SUCCESS) {
-		sd_err("failed to update meta %"PRIx64 ", %s", oid,
+		sd_err("failed to update meta %016"PRIx64 ", %s", oid,
 		       sd_strerror(ret));
 		goto out;
 	}

--- a/sheep/nfs/fs.c
+++ b/sheep/nfs/fs.c
@@ -57,7 +57,7 @@ static int inode_do_create(struct inode_data *id)
 	ret = sd_write_object(oid, (char *)inode, INODE_META_SIZE + inode->size,
 			      0, create);
 	if (ret != SD_RES_SUCCESS) {
-		sd_err("failed to create object, %" PRIx64, oid);
+		sd_err("failed to create object, %016" PRIx64, oid);
 		goto out;
 	}
 	if (!create)
@@ -66,7 +66,7 @@ static int inode_do_create(struct inode_data *id)
 	sd_inode_set_vid(sd_inode, idx, vid);
 	ret = sd_inode_write_vid(sd_inode, idx, vid, vid, 0, false, false);
 	if (ret != SD_RES_SUCCESS) {
-		sd_err("failed to update sd inode, %" PRIx64,
+		sd_err("failed to update sd inode, %016" PRIx64,
 		       vid_to_vdi_oid(vid));
 		goto out;
 	}
@@ -227,7 +227,7 @@ static struct inode *inode_read(uint64_t ino, uint64_t size)
 
 	ret = sd_read_object(ino, (char *)inode, size, 0);
 	if (ret != SD_RES_SUCCESS) {
-		sd_err("failed to read %" PRIx64 " %s", ino, sd_strerror(ret));
+		sd_err("failed to read %016" PRIx64 " %s", ino, sd_strerror(ret));
 		free(inode);
 		inode = (struct inode *)-ret;
 	}
@@ -251,7 +251,7 @@ static int inode_write(struct inode *inode, uint64_t size)
 
 	ret = sd_write_object(oid, (char *)inode, size, 0, 0);
 	if (ret != SD_RES_SUCCESS)
-		sd_err("failed to write %" PRIx64" %s", oid, sd_strerror(ret));
+		sd_err("failed to write %016" PRIx64" %s", oid, sd_strerror(ret));
 
 	return ret;
 }
@@ -296,7 +296,7 @@ struct dentry *fs_lookup_dir(struct inode *inode, const char *name)
 	struct dentry *key = xmalloc(sizeof(*key));
 	uint64_t dentry_count = inode->size / sizeof(struct dentry);
 
-	sd_debug("%"PRIx64", %s", inode->ino, name);
+	sd_debug("%016"PRIx64", %s", inode->ino, name);
 
 	pstrcpy(key->name, NFS_MAXNAMLEN, name);
 

--- a/sheep/nfs/nfs.c
+++ b/sheep/nfs/nfs.c
@@ -119,7 +119,7 @@ void *nfs3_setattr(struct svc_req *req, struct nfs_arg *argp)
 	struct inode *inode;
 	int ret;
 
-	sd_debug("%"PRIx64, fh->ino);
+	sd_debug("%016"PRIx64, fh->ino);
 
 	inode = fs_read_inode_hdr(fh->ino);
 	if (IS_ERR(inode)) {
@@ -165,7 +165,7 @@ void *nfs3_lookup(struct svc_req *req, struct nfs_arg *argp)
 	struct dentry *dentry;
 	char *name = arg->what.name;
 
-	sd_debug("%"PRIx64" %s", fh->ino, name);
+	sd_debug("%016"PRIx64" %s", fh->ino, name);
 
 	inode = fs_read_inode_full(fh->ino);
 	if (IS_ERR(inode)) {
@@ -264,7 +264,7 @@ void *nfs3_read(struct svc_req *req, struct nfs_arg *argp)
 	struct inode *inode;
 	int ret;
 
-	sd_debug("%"PRIx64"count %"PRIu64" offset %"PRIu64, fh->ino,
+	sd_debug("%016"PRIx64"count %"PRIu64" offset %"PRIu64, fh->ino,
 		 count, offset);
 
 	inode = fs_read_inode_full(fh->ino);
@@ -310,7 +310,7 @@ void *nfs3_write(struct svc_req *req, struct nfs_arg *argp)
 	int64_t done;
 	void *buffer = arg->data.data_val;
 
-	sd_debug("%"PRIx64" count %"PRIu64" offset %"PRIu64" stable %d",
+	sd_debug("%016"PRIx64" count %"PRIu64" offset %"PRIu64" stable %d",
 		 fh->ino, count, offset, arg->stable);
 
 	inode = fs_read_inode_full(fh->ino);
@@ -358,7 +358,7 @@ void *nfs3_create(struct svc_req *req, struct nfs_arg *argp)
 	char *name = arg->where.name;
 	int mode = arg->how.mode, ret;
 
-	sd_debug("%"PRIx64" %s, mode %d, size %"PRIu64, fh->ino, name, mode,
+	sd_debug("%016"PRIx64" %s, mode %d, size %"PRIu64, fh->ino, name, mode,
 		 sattr->size.size);
 
 	new->mode = S_IFREG | sd_def_fmode;
@@ -399,7 +399,7 @@ void *nfs3_mkdir(struct svc_req *req, struct nfs_arg *argp)
 	char *name = arg->where.name;
 	int ret;
 
-	sd_debug("%"PRIx64" %s", fh->ino, name);
+	sd_debug("%016"PRIx64" %s", fh->ino, name);
 
 	parent = fs_read_inode_full(fh->ino);
 	if (IS_ERR(parent)) {
@@ -565,7 +565,7 @@ void *nfs3_readdir(struct svc_req *req, struct nfs_arg *argp)
 	struct dir_reader_d wd;
 	int ret;
 
-	sd_debug("%"PRIx64" count %"PRIu32", at %"PRIu64, fh->ino,
+	sd_debug("%016"PRIx64" count %"PRIu32", at %"PRIu64, fh->ino,
 		 (uint32_t)arg->count, arg->cookie);
 
 	inode = fs_read_inode_full(fh->ino);

--- a/sheep/object_list_cache.c
+++ b/sheep/object_list_cache.c
@@ -173,7 +173,7 @@ static void objlist_deletion_work(struct work *work)
 		if (is_vdi_obj(entry->oid))
 			continue;
 
-		sd_debug("delete object entry %" PRIx64, entry->oid);
+		sd_debug("delete object entry %016" PRIx64, entry->oid);
 		rb_erase(&entry->node, &obj_list_cache.root);
 		free(entry);
 	}

--- a/sheep/ops.c
+++ b/sheep/ops.c
@@ -883,7 +883,7 @@ static int local_discard_obj(struct request *req)
 	int ret, idx = data_oid_to_idx(oid);
 	struct sd_inode *inode = xmalloc(sizeof(struct sd_inode));
 
-	sd_debug("%"PRIx64, oid);
+	sd_debug("%016"PRIx64, oid);
 	ret = sd_read_object(vid_to_vdi_oid(vid), (char *)inode,
 			     sizeof(struct sd_inode), 0);
 	if (ret != SD_RES_SUCCESS)
@@ -897,7 +897,7 @@ static int local_discard_obj(struct request *req)
 		if (ret != SD_RES_SUCCESS)
 			goto out;
 		if (sd_remove_object(oid) != SD_RES_SUCCESS)
-			sd_err("failed to remove %"PRIx64, oid);
+			sd_err("failed to remove %016"PRIx64, oid);
 	}
 	/*
 	 * Return success even if sd_remove_object fails because we have updated
@@ -1150,7 +1150,7 @@ int peer_decref_object(struct request *req)
 	bool exist = false, locked;
 	static struct sd_mutex lock = SD_MUTEX_INITIALIZER;
 
-	sd_debug("%" PRIx64 ", %" PRIu32 ", %" PRIu32 ", %" PRIu32,
+	sd_debug("%016" PRIx64 ", %" PRIu32 ", %" PRIu32 ", %" PRIu32,
 		 ledger_oid, epoch, generation, count);
 
 	ledger = xvalloc(SD_LEDGER_OBJ_SIZE);
@@ -1176,7 +1176,7 @@ int peer_decref_object(struct request *req)
 		ledger[0] = 1;
 		break;
 	default:
-		sd_err("failed to read ledger object %"PRIx64": %s",
+		sd_err("failed to read ledger object %016"PRIx64": %s",
 		       ledger_oid, sd_strerror(ret));
 		goto out;
 	}
@@ -1223,7 +1223,7 @@ int peer_decref_object(struct request *req)
 			ret = sd_store->create_and_write(ledger_oid, &iocb);
 
 		if (ret != SD_RES_SUCCESS)
-			sd_err("failed to update ledger object %"PRIx64": %s",
+			sd_err("failed to update ledger object %016"PRIx64": %s",
 			       ledger_oid, sd_strerror(ret));
 	}
 out:
@@ -1989,14 +1989,14 @@ void do_process_work(struct work *work)
 	struct request *req = container_of(work, struct request, work);
 	int ret = SD_RES_SUCCESS;
 
-	sd_debug("%x, %" PRIx64", %"PRIu32, req->rq.opcode, req->rq.obj.oid,
+	sd_debug("%x, %016" PRIx64", %"PRIu32, req->rq.opcode, req->rq.obj.oid,
 		 req->rq.epoch);
 
 	if (req->op->process_work)
 		ret = req->op->process_work(req);
 
 	if (ret != SD_RES_SUCCESS) {
-		sd_debug("failed: %x, %" PRIx64" , %u, %s", req->rq.opcode,
+		sd_debug("failed: %x, %016" PRIx64" , %u, %s", req->rq.opcode,
 			 req->rq.obj.oid, req->rq.epoch, sd_strerror(ret));
 	}
 

--- a/sheep/request.c
+++ b/sheep/request.c
@@ -198,7 +198,7 @@ static bool request_in_recovery(struct request *req)
 		return false;
 
 	if (oid_in_recovery(req->local_oid)) {
-		sd_debug("%"PRIx64" wait on oid", req->local_oid);
+		sd_debug("%016"PRIx64" wait on oid", req->local_oid);
 		sleep_on_wait_queue(req);
 		return true;
 	}
@@ -221,7 +221,7 @@ void wakeup_requests_on_epoch(void)
 			 * its epoch changes.
 			 */
 			sd_assert(is_gateway_op(req->op));
-			sd_debug("gateway %"PRIx64, req->rq.obj.oid);
+			sd_debug("gateway %016"PRIx64, req->rq.obj.oid);
 			req->rq.epoch = sys->cinfo.epoch;
 			del_requeue_request(req);
 			break;
@@ -231,7 +231,7 @@ void wakeup_requests_on_epoch(void)
 			 * changes.
 			 */
 			sd_assert(!is_gateway_op(req->op));
-			sd_debug("peer %"PRIx64, req->rq.obj.oid);
+			sd_debug("peer %016"PRIx64, req->rq.obj.oid);
 			del_requeue_request(req);
 			break;
 		default:
@@ -253,7 +253,7 @@ void wakeup_requests_on_oid(uint64_t oid)
 	list_for_each_entry(req, &pending_list, request_list) {
 		if (req->local_oid != oid)
 			continue;
-		sd_debug("retry %" PRIx64, req->local_oid);
+		sd_debug("retry %016" PRIx64, req->local_oid);
 		del_requeue_request(req);
 	}
 	list_splice_init(&pending_list, &sys->req_wait_queue);
@@ -267,7 +267,7 @@ void wakeup_all_requests(void)
 	list_splice_init(&sys->req_wait_queue, &pending_list);
 
 	list_for_each_entry(req, &pending_list, request_list) {
-		sd_debug("%"PRIx64, req->rq.obj.oid);
+		sd_debug("%016"PRIx64, req->rq.obj.oid);
 		del_requeue_request(req);
 	}
 }

--- a/sheep/store/common.c
+++ b/sheep/store/common.c
@@ -37,7 +37,7 @@ int prepare_iocb(uint64_t oid, const struct siocb *iocb, bool create)
 
 	if (sys->backend_dio && is_data_obj(oid) && iocb_is_aligned(iocb)) {
 		if (!is_aligned_to_pagesize(iocb->buf))
-			panic("Memory isn't aligned to pagesize %p, oid: %"PRIx64, iocb->buf, oid);
+			panic("Memory isn't aligned to pagesize %p, oid: %016"PRIx64, iocb->buf, oid);
 		flags |= O_DIRECT;
 	}
 
@@ -67,18 +67,18 @@ int err_to_sderr(const char *path, uint64_t oid, int err)
 		return SD_RES_NO_OBJ;
 	case ENOSPC:
 		/* TODO: stop automatic recovery */
-		sd_err("diskfull, oid=%"PRIx64, oid);
+		sd_err("diskfull, oid=%016"PRIx64, oid);
 		return SD_RES_NO_SPACE;
 	case EMFILE:
 	case ENFILE:
 	case EINTR:
 	case EAGAIN:
 	case EEXIST:
-		sd_err("%m, oid=%"PRIx64, oid);
+		sd_err("%m, oid=%016"PRIx64, oid);
 		/* make gateway try again */
 		return SD_RES_NETWORK_ERROR;
 	default:
-		sd_err("oid=%"PRIx64", %m", oid);
+		sd_err("oid=%016"PRIx64", %m", oid);
 		return md_handle_eio(dir);
 	}
 }
@@ -476,7 +476,7 @@ int sd_write_object(uint64_t oid, char *data, unsigned int datalen,
 
 	ret = exec_local_req(&hdr, data);
 	if (ret != SD_RES_SUCCESS)
-		sd_err("failed to write object %" PRIx64 ", %s", oid,
+		sd_err("failed to write object %016" PRIx64 ", %s", oid,
 			   sd_strerror(ret));
 
 	return ret;
@@ -495,7 +495,7 @@ int sd_read_object(uint64_t oid, char *data, unsigned int datalen,
 
 	ret = exec_local_req(&hdr, data);
 	if (ret != SD_RES_SUCCESS)
-		sd_err("failed to read object %" PRIx64 ", %s", oid,
+		sd_err("failed to read object %016" PRIx64 ", %s", oid,
 		       sd_strerror(ret));
 	return ret;
 }
@@ -510,7 +510,7 @@ int sd_remove_object(uint64_t oid)
 
 	ret = exec_local_req(&hdr, NULL);
 	if (ret != SD_RES_SUCCESS)
-		sd_err("failed to remove object %" PRIx64 ", %s", oid,
+		sd_err("failed to remove object %016" PRIx64 ", %s", oid,
 		       sd_strerror(ret));
 
 	return ret;
@@ -539,7 +539,7 @@ int sd_dec_object_refcnt(uint64_t data_oid, uint32_t generation,
 	int ret;
 	uint64_t ledger_oid = data_oid_to_ledger_oid(data_oid);
 
-	sd_debug("%"PRIx64", %" PRId32 ", %" PRId32,
+	sd_debug("%016"PRIx64", %" PRId32 ", %" PRId32,
 		 data_oid, generation, refcnt);
 
 	if (generation == 0 && refcnt == 0)
@@ -552,7 +552,7 @@ int sd_dec_object_refcnt(uint64_t data_oid, uint32_t generation,
 
 	ret = exec_local_req(&hdr, NULL);
 	if (ret != SD_RES_SUCCESS)
-		sd_err("failed to decrement reference %" PRIx64 ", %s",
+		sd_err("failed to decrement reference %016" PRIx64 ", %s",
 		       ledger_oid, sd_strerror(ret));
 
 	return ret;

--- a/sheep/store/plain_store.c
+++ b/sheep/store/plain_store.c
@@ -61,7 +61,7 @@ static int default_trim(int fd, uint64_t oid, const struct siocb *iocb,
 	trim_zero_blocks(iocb->buf, poffset, plen);
 
 	if (iocb->offset < *poffset) {
-		sd_debug("discard between %d, %ld, %" PRIx64, iocb->offset,
+		sd_debug("discard between %d, %ld, %016" PRIx64, iocb->offset,
 			 *poffset, oid);
 
 		if (discard(fd, iocb->offset, *poffset) < 0)
@@ -74,7 +74,7 @@ static int default_trim(int fd, uint64_t oid, const struct siocb *iocb,
 		if (end == get_objsize(oid, object_size))
 			/* This is necessary to punch the last block */
 			end = round_up(end, BLOCK_SIZE);
-		sd_debug("discard between %ld, %ld, %" PRIx64, *poffset + *plen,
+		sd_debug("discard between %ld, %ld, %016" PRIx64, *poffset + *plen,
 			 end, oid);
 
 		if (discard(fd, *poffset + *plen, end) < 0)
@@ -133,7 +133,7 @@ int default_write(uint64_t oid, const struct siocb *iocb)
 
 	size = xpwrite(fd, iocb->buf, len, offset);
 	if (unlikely(size != len)) {
-		sd_err("failed to write object %"PRIx64", path=%s, offset=%"
+		sd_err("failed to write object %016"PRIx64", path=%s, offset=%"
 		       PRId32", size=%"PRId32", result=%zd, %m", oid, path,
 		       iocb->offset, iocb->length, size);
 		ret = err_to_sderr(path, oid, errno);
@@ -199,7 +199,7 @@ static int init_vdi_state(uint64_t oid, const char *wd, uint32_t epoch)
 
 	ret = default_read(oid, &iocb);
 	if (ret != SD_RES_SUCCESS) {
-		sd_err("failed to read inode header %" PRIx64 " %" PRId32
+		sd_err("failed to read inode header %016" PRIx64 " %" PRId32
 		       "wat %s", oid, epoch, wd);
 		goto out;
 	}
@@ -227,7 +227,7 @@ static int init_objlist_and_vdi_bitmap(uint64_t oid, const char *wd,
 	objlist_cache_insert(oid);
 
 	if (is_vdi_obj(oid)) {
-		sd_debug("found the VDI object %" PRIx64" epoch %"PRIu32
+		sd_debug("found the VDI object %016" PRIx64" epoch %"PRIu32
 			 " at %s", oid, epoch, wd);
 		ret = init_vdi_state(oid, wd, epoch);
 		if (ret != SD_RES_SUCCESS)
@@ -273,7 +273,7 @@ static int default_read_from_path(uint64_t oid, const char *path,
 
 	size = xpread(fd, iocb->buf, iocb->length, iocb->offset);
 	if (size < 0) {
-		sd_err("failed to read object %"PRIx64", path=%s, offset=%"
+		sd_err("failed to read object %016"PRIx64", path=%s, offset=%"
 		       PRId32", size=%"PRId32", result=%zd, %m", oid, path,
 		       iocb->offset, iocb->length, size);
 		ret = err_to_sderr(path, oid, errno);
@@ -314,7 +314,7 @@ int default_create_and_write(uint64_t oid, const struct siocb *iocb)
 	size_t obj_size;
 	uint64_t offset = iocb->offset;
 
-	sd_debug("%"PRIx64, oid);
+	sd_debug("%016"PRIx64, oid);
 	get_store_path(oid, iocb->ec_index, path);
 	get_store_tmp_path(oid, iocb->ec_index, tmp_path);
 
@@ -415,7 +415,7 @@ int default_link(uint64_t oid, uint32_t tgt_epoch)
 {
 	char path[PATH_MAX], stale_path[PATH_MAX];
 
-	sd_debug("try link %"PRIx64" from snapshot with epoch %d", oid,
+	sd_debug("try link %016"PRIx64" from snapshot with epoch %d", oid,
 		 tgt_epoch);
 
 	snprintf(path, PATH_MAX, "%s/%016"PRIx64, md_get_object_dir(oid), oid);
@@ -496,7 +496,7 @@ static int move_object_to_stale_dir(uint64_t oid, const char *wd,
 		return SD_RES_EIO;
 	}
 
-	sd_debug("moved object %"PRIx64, oid);
+	sd_debug("moved object %016"PRIx64, oid);
 	return SD_RES_SUCCESS;
 }
 
@@ -628,7 +628,7 @@ int default_get_hash(uint64_t oid, uint32_t epoch, uint8_t *sha1)
 	get_buffer_sha1(buf, length, sha1);
 	free(buf);
 
-	sd_debug("the message digest of %"PRIx64" at epoch %d is %s", oid,
+	sd_debug("the message digest of %016"PRIx64" at epoch %d is %s", oid,
 		 epoch, sha1_to_hex(sha1));
 
 	if (is_readonly_obj)

--- a/sheep/store/tree_store.c
+++ b/sheep/store/tree_store.c
@@ -76,7 +76,7 @@ static int tree_trim(int fd, uint64_t oid, const struct siocb *iocb,
 	trim_zero_blocks(iocb->buf, poffset, plen);
 
 	if (iocb->offset < *poffset) {
-		sd_debug("discard between %d, %ld, %" PRIx64, iocb->offset,
+		sd_debug("discard between %d, %ld, %016" PRIx64, iocb->offset,
 			 *poffset, oid);
 
 		if (discard(fd, iocb->offset, *poffset) < 0)
@@ -89,7 +89,7 @@ static int tree_trim(int fd, uint64_t oid, const struct siocb *iocb,
 		if (end == get_objsize(oid, object_size))
 			/* This is necessary to punch the last block */
 			end = round_up(end, BLOCK_SIZE);
-		sd_debug("discard between %ld, %ld, %" PRIx64, *poffset + *plen,
+		sd_debug("discard between %ld, %ld, %016" PRIx64, *poffset + *plen,
 			 end, oid);
 
 		if (discard(fd, *poffset + *plen, end) < 0)
@@ -148,7 +148,7 @@ int tree_write(uint64_t oid, const struct siocb *iocb)
 
 	size = xpwrite(fd, iocb->buf, len, offset);
 	if (unlikely(size != len)) {
-		sd_err("failed to write object %"PRIx64", path=%s, offset=%"
+		sd_err("failed to write object %016"PRIx64", path=%s, offset=%"
 		       PRId32", size=%"PRId32", result=%zd, %m", oid, path,
 		       iocb->offset, iocb->length, size);
 		ret = err_to_sderr(path, oid, errno);
@@ -237,7 +237,7 @@ static int init_vdi_state(uint64_t oid, const char *wd, uint32_t epoch)
 
 	ret = tree_read(oid, &iocb);
 	if (ret != SD_RES_SUCCESS) {
-		sd_err("failed to read inode header %" PRIx64 " %" PRId32
+		sd_err("failed to read inode header %016" PRIx64 " %" PRId32
 		       "wat %s", oid, epoch, wd);
 		goto out;
 	}
@@ -268,7 +268,7 @@ static int init_objlist_and_vdi_bitmap(uint64_t oid, const char *wd,
 	snprintf(path, PATH_MAX, "%s/meta", wd);
 
 	if (is_vdi_obj(oid)) {
-		sd_debug("found the VDI object %" PRIx64" epoch %"PRIu32
+		sd_debug("found the VDI object %016" PRIx64" epoch %"PRIu32
 			 " at %s", oid, epoch, path);
 		ret = init_vdi_state(oid, path, epoch);
 		if (ret != SD_RES_SUCCESS)
@@ -319,7 +319,7 @@ static int tree_read_from_path(uint64_t oid, const char *path,
 
 	size = xpread(fd, iocb->buf, iocb->length, iocb->offset);
 	if (size < 0) {
-		sd_err("failed to read object %"PRIx64", path=%s, offset=%"
+		sd_err("failed to read object %016"PRIx64", path=%s, offset=%"
 		       PRId32", size=%"PRId32", result=%zd, %m", oid, path,
 		       iocb->offset, iocb->length, size);
 		ret = err_to_sderr(path, oid, errno);
@@ -359,7 +359,7 @@ int tree_create_and_write(uint64_t oid, const struct siocb *iocb)
 	size_t obj_size;
 	uint64_t offset = iocb->offset;
 
-	sd_debug("%"PRIx64, oid);
+	sd_debug("%016"PRIx64, oid);
 	get_store_path(oid, iocb->ec_index, path);
 	get_store_tmp_path(oid, iocb->ec_index, tmp_path);
 
@@ -468,7 +468,7 @@ int tree_link(uint64_t oid, uint32_t tgt_epoch)
 			 md_get_object_dir(oid), get_tree_directory(oid));
 	}
 
-	sd_debug("try link %"PRIx64" from snapshot with epoch %d", oid,
+	sd_debug("try link %016"PRIx64" from snapshot with epoch %d", oid,
 		 tgt_epoch);
 
 	snprintf(path, PATH_MAX, "%s/%016"PRIx64, tree_path, oid);
@@ -556,7 +556,7 @@ static int move_object_to_stale_dir(uint64_t oid, const char *wd,
 		       path);
 		return SD_RES_EIO;
 	}
-	sd_debug("moved object %"PRIx64, oid);
+	sd_debug("moved object %016"PRIx64, oid);
 	return SD_RES_SUCCESS;
 }
 
@@ -698,7 +698,7 @@ int tree_get_hash(uint64_t oid, uint32_t epoch, uint8_t *sha1)
 	get_buffer_sha1(buf, length, sha1);
 	free(buf);
 
-	sd_debug("the message digest of %"PRIx64" at epoch %d is %s", oid,
+	sd_debug("the message digest of %016"PRIx64" at epoch %d is %s", oid,
 		 epoch, sha1_to_hex(sha1));
 
 	if (is_readonly_obj)

--- a/sheep/vdi.c
+++ b/sheep/vdi.c
@@ -1742,12 +1742,12 @@ static void delete_cb(struct sd_index *idx, void *arg, int ignore)
 	if (idx->vdi_id) {
 		oid = vid_to_data_oid(idx->vdi_id, idx->idx);
 		if (idx->vdi_id != darg->inode->vdi_id)
-			sd_debug("object %" PRIx64 " is base's data, would"
+			sd_debug("object %016" PRIx64 " is base's data, would"
 				 " not be deleted.", oid);
 		else {
 			ret = sd_remove_object(oid);
 			if (ret != SD_RES_SUCCESS)
-				sd_err("remove object %" PRIx64 " fail, %d",
+				sd_err("remove object %016" PRIx64 " fail, %d",
 				       oid, ret);
 			(*(darg->nr_deleted))++;
 		}
@@ -2189,7 +2189,7 @@ static int clean_matched_obj(uint64_t oid, const char *path,
 	int ret = SD_RES_SUCCESS;
 
 	if (oid_to_vid(oid) == vid) {
-		sd_info("removing object %"PRIx64" (path: %s), it means the"
+		sd_info("removing object %016"PRIx64" (path: %s), it means the"
 			" object is leaked", oid, path);
 		ret = unlink(path);
 		if (ret) {

--- a/sheepfs/volume.c
+++ b/sheepfs/volume.c
@@ -175,7 +175,7 @@ static int volume_rw_object(char *buf, uint64_t oid, size_t size,
 	put_socket_fd(vdi, sock_idx);
 
 	if (ret || rsp->result != SD_RES_SUCCESS) {
-		sheepfs_pr("failed to %s object %" PRIx64 " ret %d, res %s\n",
+		sheepfs_pr("failed to %s object %016" PRIx64 " ret %d, res %s\n",
 			   rw == VOLUME_READ ? "read" : "write",
 			   oid, ret, sd_strerror(rsp->result));
 		return -1;
@@ -226,7 +226,7 @@ static ssize_t volume_do_rw(const char *path, char *buf, size_t size,
 
 	do {
 #ifdef DEBUG
-		sheepfs_pr("%s oid %"PRIx64", off %ju, len %zu,"
+		sheepfs_pr("%s oid %016"PRIx64", off %ju, len %zu,"
 			   " size %zu\n",
 			   rw == VOLUME_READ ? "read" : "write",
 			   oid, start, len, size);

--- a/tests/functional/028.out
+++ b/tests/functional/028.out
@@ -11,175 +11,175 @@ Looking for the inode object 0x7c2b25 with 2 nodes
 
 According to sheepdog algorithm, the object should be located at:
 127.0.0.1:7001 127.0.0.1:7000
-Looking for the object 0x7c2b2500000000 (vid 0x7c2b25 idx 0, 2 copies) with 2 nodes
+Looking for the object 007c2b2500000000 (vid 0x7c2b25 idx 0, 2 copies) with 2 nodes
 
 127.0.0.1:7000 has the object
 127.0.0.1:7001 has the object
 
 According to sheepdog algorithm, the object should be located at:
 127.0.0.1:7001 127.0.0.1:7000
-Looking for the object 0x7c2b2500000001 (vid 0x7c2b25 idx 1, 2 copies) with 2 nodes
+Looking for the object 007c2b2500000001 (vid 0x7c2b25 idx 1, 2 copies) with 2 nodes
 
 127.0.0.1:7000 has the object
 127.0.0.1:7001 has the object
 
 According to sheepdog algorithm, the object should be located at:
 127.0.0.1:7000 127.0.0.1:7001
-Looking for the object 0x7c2b2500000002 (vid 0x7c2b25 idx 2, 2 copies) with 2 nodes
+Looking for the object 007c2b2500000002 (vid 0x7c2b25 idx 2, 2 copies) with 2 nodes
 
 127.0.0.1:7000 has the object
 127.0.0.1:7001 has the object
 
 According to sheepdog algorithm, the object should be located at:
 127.0.0.1:7000 127.0.0.1:7001
-Looking for the object 0x7c2b2500000003 (vid 0x7c2b25 idx 3, 2 copies) with 2 nodes
+Looking for the object 007c2b2500000003 (vid 0x7c2b25 idx 3, 2 copies) with 2 nodes
 
 127.0.0.1:7000 has the object
 127.0.0.1:7001 has the object
 
 According to sheepdog algorithm, the object should be located at:
 127.0.0.1:7001 127.0.0.1:7000
-Looking for the object 0x7c2b2500000004 (vid 0x7c2b25 idx 4, 2 copies) with 2 nodes
+Looking for the object 007c2b2500000004 (vid 0x7c2b25 idx 4, 2 copies) with 2 nodes
 
 127.0.0.1:7000 has the object
 127.0.0.1:7001 has the object
 
 According to sheepdog algorithm, the object should be located at:
 127.0.0.1:7000 127.0.0.1:7001
-Looking for the object 0x7c2b2500000005 (vid 0x7c2b25 idx 5, 2 copies) with 2 nodes
+Looking for the object 007c2b2500000005 (vid 0x7c2b25 idx 5, 2 copies) with 2 nodes
 
 127.0.0.1:7000 has the object
 127.0.0.1:7001 has the object
 
 According to sheepdog algorithm, the object should be located at:
 127.0.0.1:7001 127.0.0.1:7000
-Looking for the object 0x7c2b2500000006 (vid 0x7c2b25 idx 6, 2 copies) with 2 nodes
+Looking for the object 007c2b2500000006 (vid 0x7c2b25 idx 6, 2 copies) with 2 nodes
 
 127.0.0.1:7000 has the object
 127.0.0.1:7001 has the object
 
 According to sheepdog algorithm, the object should be located at:
 127.0.0.1:7000 127.0.0.1:7001
-Looking for the object 0x7c2b2500000007 (vid 0x7c2b25 idx 7, 2 copies) with 2 nodes
+Looking for the object 007c2b2500000007 (vid 0x7c2b25 idx 7, 2 copies) with 2 nodes
 
 127.0.0.1:7000 has the object
 127.0.0.1:7001 has the object
 
 According to sheepdog algorithm, the object should be located at:
 127.0.0.1:7000 127.0.0.1:7001
-Looking for the object 0x7c2b2500000008 (vid 0x7c2b25 idx 8, 2 copies) with 2 nodes
+Looking for the object 007c2b2500000008 (vid 0x7c2b25 idx 8, 2 copies) with 2 nodes
 
 127.0.0.1:7000 has the object
 127.0.0.1:7001 has the object
 
 According to sheepdog algorithm, the object should be located at:
 127.0.0.1:7001 127.0.0.1:7000
-Looking for the object 0x7c2b2500000009 (vid 0x7c2b25 idx 9, 2 copies) with 2 nodes
+Looking for the object 007c2b2500000009 (vid 0x7c2b25 idx 9, 2 copies) with 2 nodes
 
 127.0.0.1:7000 has the object
 127.0.0.1:7001 has the object
 
 According to sheepdog algorithm, the object should be located at:
 127.0.0.1:7001 127.0.0.1:7000
-Looking for the object 0x7c2b250000000a (vid 0x7c2b25 idx 10, 2 copies) with 2 nodes
+Looking for the object 007c2b250000000a (vid 0x7c2b25 idx 10, 2 copies) with 2 nodes
 
 127.0.0.1:7000 has the object
 127.0.0.1:7001 has the object
 
 According to sheepdog algorithm, the object should be located at:
 127.0.0.1:7001 127.0.0.1:7000
-Looking for the object 0x7c2b250000000b (vid 0x7c2b25 idx 11, 2 copies) with 2 nodes
+Looking for the object 007c2b250000000b (vid 0x7c2b25 idx 11, 2 copies) with 2 nodes
 
 127.0.0.1:7000 has the object
 127.0.0.1:7001 has the object
 
 According to sheepdog algorithm, the object should be located at:
 127.0.0.1:7000 127.0.0.1:7001
-Looking for the object 0x7c2b250000000c (vid 0x7c2b25 idx 12, 2 copies) with 2 nodes
+Looking for the object 007c2b250000000c (vid 0x7c2b25 idx 12, 2 copies) with 2 nodes
 
 127.0.0.1:7000 has the object
 127.0.0.1:7001 has the object
 
 According to sheepdog algorithm, the object should be located at:
 127.0.0.1:7001 127.0.0.1:7000
-Looking for the object 0x7c2b250000000d (vid 0x7c2b25 idx 13, 2 copies) with 2 nodes
+Looking for the object 007c2b250000000d (vid 0x7c2b25 idx 13, 2 copies) with 2 nodes
 
 127.0.0.1:7000 has the object
 127.0.0.1:7001 has the object
 
 According to sheepdog algorithm, the object should be located at:
 127.0.0.1:7001 127.0.0.1:7000
-Looking for the object 0x7c2b250000000e (vid 0x7c2b25 idx 14, 2 copies) with 2 nodes
+Looking for the object 007c2b250000000e (vid 0x7c2b25 idx 14, 2 copies) with 2 nodes
 
 127.0.0.1:7000 has the object
 127.0.0.1:7001 has the object
 
 According to sheepdog algorithm, the object should be located at:
 127.0.0.1:7001 127.0.0.1:7000
-Looking for the object 0x7c2b250000000f (vid 0x7c2b25 idx 15, 2 copies) with 2 nodes
+Looking for the object 007c2b250000000f (vid 0x7c2b25 idx 15, 2 copies) with 2 nodes
 
 127.0.0.1:7000 has the object
 127.0.0.1:7001 has the object
 
 According to sheepdog algorithm, the object should be located at:
 127.0.0.1:7001 127.0.0.1:7000
-Looking for the object 0x7c2b2500000010 (vid 0x7c2b25 idx 16, 2 copies) with 2 nodes
+Looking for the object 007c2b2500000010 (vid 0x7c2b25 idx 16, 2 copies) with 2 nodes
 
 127.0.0.1:7000 has the object
 127.0.0.1:7001 has the object
 
 According to sheepdog algorithm, the object should be located at:
 127.0.0.1:7000 127.0.0.1:7001
-Looking for the object 0x7c2b2500000011 (vid 0x7c2b25 idx 17, 2 copies) with 2 nodes
+Looking for the object 007c2b2500000011 (vid 0x7c2b25 idx 17, 2 copies) with 2 nodes
 
 127.0.0.1:7000 has the object
 127.0.0.1:7001 has the object
 
 According to sheepdog algorithm, the object should be located at:
 127.0.0.1:7001 127.0.0.1:7000
-Looking for the object 0x7c2b2500000012 (vid 0x7c2b25 idx 18, 2 copies) with 2 nodes
+Looking for the object 007c2b2500000012 (vid 0x7c2b25 idx 18, 2 copies) with 2 nodes
 
 127.0.0.1:7000 has the object
 127.0.0.1:7001 has the object
 
 According to sheepdog algorithm, the object should be located at:
 127.0.0.1:7001 127.0.0.1:7000
-Looking for the object 0x7c2b2500000013 (vid 0x7c2b25 idx 19, 2 copies) with 2 nodes
+Looking for the object 007c2b2500000013 (vid 0x7c2b25 idx 19, 2 copies) with 2 nodes
 
 127.0.0.1:7000 has the object
 127.0.0.1:7001 has the object
 
 According to sheepdog algorithm, the object should be located at:
 127.0.0.1:7000 127.0.0.1:7001
-Looking for the object 0x7c2b2500000014 (vid 0x7c2b25 idx 20, 2 copies) with 2 nodes
+Looking for the object 007c2b2500000014 (vid 0x7c2b25 idx 20, 2 copies) with 2 nodes
 
 127.0.0.1:7000 has the object
 127.0.0.1:7001 has the object
 
 According to sheepdog algorithm, the object should be located at:
 127.0.0.1:7001 127.0.0.1:7000
-Looking for the object 0x7c2b2500000015 (vid 0x7c2b25 idx 21, 2 copies) with 2 nodes
+Looking for the object 007c2b2500000015 (vid 0x7c2b25 idx 21, 2 copies) with 2 nodes
 
 127.0.0.1:7000 has the object
 127.0.0.1:7001 has the object
 
 According to sheepdog algorithm, the object should be located at:
 127.0.0.1:7000 127.0.0.1:7001
-Looking for the object 0x7c2b2500000016 (vid 0x7c2b25 idx 22, 2 copies) with 2 nodes
+Looking for the object 007c2b2500000016 (vid 0x7c2b25 idx 22, 2 copies) with 2 nodes
 
 127.0.0.1:7000 has the object
 127.0.0.1:7001 has the object
 
 According to sheepdog algorithm, the object should be located at:
 127.0.0.1:7000 127.0.0.1:7001
-Looking for the object 0x7c2b2500000017 (vid 0x7c2b25 idx 23, 2 copies) with 2 nodes
+Looking for the object 007c2b2500000017 (vid 0x7c2b25 idx 23, 2 copies) with 2 nodes
 
 127.0.0.1:7000 has the object
 127.0.0.1:7001 has the object
 
 According to sheepdog algorithm, the object should be located at:
 127.0.0.1:7001 127.0.0.1:7000
-Looking for the object 0x7c2b2500000018 (vid 0x7c2b25 idx 24, 2 copies) with 2 nodes
+Looking for the object 007c2b2500000018 (vid 0x7c2b25 idx 24, 2 copies) with 2 nodes
 
 127.0.0.1:7000 has the object
 127.0.0.1:7001 has the object

--- a/tests/functional/042.out
+++ b/tests/functional/042.out
@@ -1,48 +1,48 @@
 QA output created by 042
 using backend plain store
-Failed to write object fd34af00000000: Server has no space for new objects
+Failed to write object 00fd34af00000000: Server has no space for new objects
 Failed to write VDI
-Failed to write object fd32fc00000000: Server has no space for new objects
+Failed to write object 00fd32fc00000000: Server has no space for new objects
 Failed to write VDI
-Failed to write object fd34af00000001: Server has no space for new objects
+Failed to write object 00fd34af00000001: Server has no space for new objects
 Failed to write VDI
-Failed to write object fd32fc00000001: Server has no space for new objects
+Failed to write object 00fd32fc00000001: Server has no space for new objects
 Failed to write VDI
-Failed to write object fd34af00000002: Server has no space for new objects
+Failed to write object 00fd34af00000002: Server has no space for new objects
 Failed to write VDI
-Failed to write object fd32fc00000002: Server has no space for new objects
+Failed to write object 00fd32fc00000002: Server has no space for new objects
 Failed to write VDI
-Failed to write object fd34af00000003: Server has no space for new objects
+Failed to write object 00fd34af00000003: Server has no space for new objects
 Failed to write VDI
-Failed to write object fd32fc00000003: Server has no space for new objects
+Failed to write object 00fd32fc00000003: Server has no space for new objects
 Failed to write VDI
-Failed to write object fd34af00000004: Server has no space for new objects
+Failed to write object 00fd34af00000004: Server has no space for new objects
 Failed to write VDI
-Failed to write object fd32fc00000004: Server has no space for new objects
+Failed to write object 00fd32fc00000004: Server has no space for new objects
 Failed to write VDI
-Failed to write object fd34af00000005: Server has no space for new objects
+Failed to write object 00fd34af00000005: Server has no space for new objects
 Failed to write VDI
-Failed to write object fd32fc00000005: Server has no space for new objects
+Failed to write object 00fd32fc00000005: Server has no space for new objects
 Failed to write VDI
-Failed to write object fd34af00000006: Server has no space for new objects
+Failed to write object 00fd34af00000006: Server has no space for new objects
 Failed to write VDI
-Failed to write object fd32fc00000006: Server has no space for new objects
+Failed to write object 00fd32fc00000006: Server has no space for new objects
 Failed to write VDI
-Failed to write object fd34af00000007: Server has no space for new objects
+Failed to write object 00fd34af00000007: Server has no space for new objects
 Failed to write VDI
-Failed to write object fd32fc00000007: Server has no space for new objects
+Failed to write object 00fd32fc00000007: Server has no space for new objects
 Failed to write VDI
-Failed to write object fd34af00000008: Server has no space for new objects
+Failed to write object 00fd34af00000008: Server has no space for new objects
 Failed to write VDI
-Failed to write object fd32fc00000008: Server has no space for new objects
+Failed to write object 00fd32fc00000008: Server has no space for new objects
 Failed to write VDI
-Failed to write object fd34af00000009: Server has no space for new objects
+Failed to write object 00fd34af00000009: Server has no space for new objects
 Failed to write VDI
-Failed to write object fd32fc00000009: Server has no space for new objects
+Failed to write object 00fd32fc00000009: Server has no space for new objects
 Failed to write VDI
-Failed to write object fd34af0000000a: Server has no space for new objects
+Failed to write object 00fd34af0000000a: Server has no space for new objects
 Failed to write VDI
-Failed to write object fd32fc0000000a: Server has no space for new objects
+Failed to write object 00fd32fc0000000a: Server has no space for new objects
 Failed to write VDI
 Failed to create VDI test2: Failed to write to requested VDI
 Failed to create VDI test3: Failed to write to requested VDI

--- a/tests/functional/080.out
+++ b/tests/functional/080.out
@@ -1,14 +1,14 @@
 QA output created by 080
 using backend plain store
-Failed to write object 7c2b2500000000: IO has halted as there are not enough living nodes
+Failed to write object 007c2b2500000000: IO has halted as there are not enough living nodes
 Failed to write VDI
   Name        Id    Size    Used  Shared    Creation time   VDI id  Copies  Tag   Block Size Shift
   test         0   10 MB  0.0 MB  0.0 MB DATE   7c2b25    4:2                22
 Failed to create VDI test1: Failed to write to requested VDI
-Failed to write object 7c2b2500000000: IO has halted as there are not enough living nodes
+Failed to write object 007c2b2500000000: IO has halted as there are not enough living nodes
 Failed to write VDI
 Failed to create VDI test1: Failed to write to requested VDI
-Failed to write object 7c2b2500000000: IO has halted as there are not enough living nodes
+Failed to write object 007c2b2500000000: IO has halted as there are not enough living nodes
 Failed to write VDI
   Name        Id    Size    Used  Shared    Creation time   VDI id  Copies  Tag   Block Size Shift
   test         0   10 MB  0.0 MB  0.0 MB DATE   7c2b25    4:2                22


### PR DESCRIPTION
This commit lets Sheepdog print object ID in 16-digit zero-padded hexadecimal, that is, `"%016" PRIx64`.

I think this is operator-friendly because s/he can tell whether that object is a data object (00...), an inode object (80...), a ledger object (08...) and so on, simply by looking at the printed.

Fix #340

Signed-off-by: Takashi Menjo &lt;menjo.takashi@lab.ntt.co.jp&gt;