### PR TITLE
RFC: lib: exponential backoff in request retry

### DIFF
--- a/dog/Makefile.am
+++ b/dog/Makefile.am
@@ -37,7 +37,7 @@ if BUILD_NFS
 dog_SOURCES		+= nfs.c
 endif
 
-dog_LDADD		= ../lib/libsd.a -lpthread
+dog_LDADD		= ../lib/libsd.a -lpthread -lm
 dog_DEPENDENCIES	= ../lib/libsd.a
 
 noinst_HEADERS		= treeview.h dog.h farm/farm.h

--- a/include/net.h
+++ b/include/net.h
@@ -18,6 +18,8 @@
 #define POLL_TIMEOUT 5 /* seconds */
 #define MAX_RETRY_COUNT (MAX_POLLTIME / POLL_TIMEOUT)
 
+#define EXP_BACKOFF_BASE (100 * 1000) /* 100 ms == 100,000 us */
+
 enum conn_state {
 	C_IO_HEADER = 0,
 	C_IO_DATA_INIT,

--- a/lib/net.c
+++ b/lib/net.c
@@ -26,6 +26,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/uio.h>
+#include <math.h>
 
 #include "sheepdog_proto.h"
 #include "sheep.h"
@@ -231,6 +232,12 @@ reread:
 		if (errno == EAGAIN && repeat &&
 		    (need_retry == NULL || need_retry(epoch))) {
 			repeat--;
+
+			/* exponential backoff */
+			usleep(random() %
+			       (long int)(pow(2.0, max_count - repeat) *
+					  EXP_BACKOFF_BASE));
+
 			goto reread;
 		}
 
@@ -276,6 +283,12 @@ rewrite:
 		if (errno == EAGAIN && repeat &&
 		    (need_retry == NULL || need_retry(epoch))) {
 			repeat--;
+
+			/* exponential backoff */
+			usleep(random() %
+			       (long int)(pow(2.0, max_count - repeat) *
+					  EXP_BACKOFF_BASE));
+
 			goto rewrite;
 		}
 

--- a/shepherd/Makefile.am
+++ b/shepherd/Makefile.am
@@ -25,7 +25,7 @@ sbin_PROGRAMS		= shepherd
 
 shepherd_SOURCES		= shepherd.c
 
-shepherd_LDADD	  	= ../lib/libsd.a -lpthread
+shepherd_LDADD	  	= ../lib/libsd.a -lpthread -lm
 shepherd_DEPENDENCIES	= ../lib/libsd.a
 
 EXTRA_DIST		=


### PR DESCRIPTION
Current sheepdog resend a request after timeout immediately. It isn't
good for avoiding high load spikes: requests that come in a short time
interval will be resent at the almost same time. This commit adds a
mechanism of exponential backoff [1] for distributing the retry
pressure.

[1] https://www.awsarchitectureblog.com/2015/03/backoff.html

Signed-off-by: Hitoshi Mitake <mitake.hitoshi@lab.ntt.co.jp>

/cc @tmenjo I'm not sure about the value of this commit yet. But if it is useful for solving the problem of  high load, how about using it?