### PR TITLE
sheep: create a dedicated workqueue for peer requests

### DIFF
--- a/include/sheepdog_proto.h
+++ b/include/sheepdog_proto.h
@@ -54,6 +54,7 @@
 /* return something back while sending something to sheep */
 #define SD_FLAG_CMD_PIGGYBACK   0x10
 #define SD_FLAG_CMD_TGT   0x20
+#define SD_FLAG_CMD_FWD   0x40
 /* flags above 0x80 are sheepdog-internal */
 
 #define SD_RES_SUCCESS       0x00 /* Success */

--- a/sheep/gateway.c
+++ b/sheep/gateway.c
@@ -658,17 +658,17 @@ static int prepare_obj_refcnt(const struct sd_req *hdr, uint32_t *vids,
 	offset = hdr->obj.offset - offsetof(struct sd_inode, data_vdi_id);
 	start = offset / sizeof(*vids);
 
-	ret = sd_read_object(hdr->obj.oid, (char *)vids,
-			     nr_vids * sizeof(vids[0]),
-			     offsetof(struct sd_inode, data_vdi_id[start]));
+	ret = sd_read_object_fwd(hdr->obj.oid, (char *)vids,
+				 nr_vids * sizeof(vids[0]),
+				 offsetof(struct sd_inode, data_vdi_id[start]));
 	if (ret != SD_RES_SUCCESS) {
 		sd_err("failed to read vdi, %016" PRIx64, hdr->obj.oid);
 		return ret;
 	}
 
-	ret = sd_read_object(hdr->obj.oid, (char *)refs,
-			     nr_vids * sizeof(refs[0]),
-			     offsetof(struct sd_inode, gref[start]));
+	ret = sd_read_object_fwd(hdr->obj.oid, (char *)refs,
+				 nr_vids * sizeof(refs[0]),
+				 offsetof(struct sd_inode, gref[start]));
 	if (ret != SD_RES_SUCCESS) {
 		sd_err("failed to read vdi, %016" PRIx64, hdr->obj.oid);
 		return ret;
@@ -837,7 +837,7 @@ int gateway_write_obj(struct request *req)
 
 		sd_debug("update reference counts, %016" PRIx64, hdr->obj.oid);
 
-		ret = sd_write_object(hdr->obj.oid, (char *)zeroed_refs,
+		ret = sd_write_object_fwd(hdr->obj.oid, (char *)zeroed_refs,
 				      nr_vids * sizeof(*zeroed_refs),
 				      offsetof(struct sd_inode, gref)
 				      + start * sizeof(*zeroed_refs), false);

--- a/sheep/gateway.c
+++ b/sheep/gateway.c
@@ -917,6 +917,7 @@ static int gateway_handle_cow(struct request *req)
 	if (req->rq.data_length != len) {
 		/* Partial write, need read the copy first */
 		sd_init_req(&hdr, SD_OP_READ_OBJ);
+		hdr.flags |= SD_FLAG_CMD_FWD;
 		hdr.obj.oid = req_hdr->obj.cow_oid;
 		hdr.data_length = len;
 		hdr.obj.offset = 0;
@@ -927,7 +928,7 @@ static int gateway_handle_cow(struct request *req)
 
 	memcpy(buf + req_hdr->obj.offset, req->data, req_hdr->data_length);
 	sd_init_req(&hdr, SD_OP_CREATE_AND_WRITE_OBJ);
-	hdr.flags = SD_FLAG_CMD_WRITE;
+	hdr.flags = SD_FLAG_CMD_WRITE | SD_FLAG_CMD_FWD;
 	hdr.obj.oid = oid;
 	hdr.data_length = len;
 	hdr.obj.offset = 0;

--- a/sheep/gateway.c
+++ b/sheep/gateway.c
@@ -872,7 +872,7 @@ int gateway_write_obj(struct request *req)
 			refcnt_work->work.fn = async_update_obj_refcnt_work;
 			refcnt_work->work.done = async_update_obj_refcnt_done;
 
-			queue_work(sys->io_wqueue, &refcnt_work->work);
+			queue_work(sys->reclaim_wqueue, &refcnt_work->work);
 			goto out;
 
 		free_work:

--- a/sheep/request.c
+++ b/sheep/request.c
@@ -287,7 +287,7 @@ static void queue_peer_request(struct request *req)
 
 	req->work.fn = do_process_work;
 	req->work.done = io_op_done;
-	queue_work(sys->io_wqueue, &req->work);
+	queue_work(sys->peer_wqueue, &req->work);
 }
 
 /*

--- a/sheep/request.c
+++ b/sheep/request.c
@@ -331,7 +331,10 @@ static void queue_gateway_request(struct request *req)
 
 	req->work.fn = do_process_work;
 	req->work.done = gateway_op_done;
-	queue_work(sys->gateway_wqueue, &req->work);
+	if (hdr->flags & SD_FLAG_CMD_FWD)
+		queue_work(sys->gateway_fwd_wqueue, &req->work);
+	else
+		queue_work(sys->gateway_wqueue, &req->work);
 	return;
 
 end_request:

--- a/sheep/request.c
+++ b/sheep/request.c
@@ -287,7 +287,11 @@ static void queue_peer_request(struct request *req)
 
 	req->work.fn = do_process_work;
 	req->work.done = io_op_done;
-	queue_work(sys->peer_wqueue, &req->work);
+
+	if (req->rq.opcode == SD_OP_REMOVE_PEER)
+		queue_work(sys->remove_peer_wqueue, &req->work);
+	else
+		queue_work(sys->peer_wqueue, &req->work);
 }
 
 /*
@@ -331,7 +335,10 @@ static void queue_gateway_request(struct request *req)
 
 	req->work.fn = do_process_work;
 	req->work.done = gateway_op_done;
-	if (hdr->flags & SD_FLAG_CMD_FWD)
+
+	if (hdr->opcode == SD_OP_REMOVE_OBJ)
+		queue_work(sys->remove_wqueue, &req->work);
+	else if (hdr->flags & SD_FLAG_CMD_FWD)
 		queue_work(sys->gateway_fwd_wqueue, &req->work);
 	else
 		queue_work(sys->gateway_wqueue, &req->work);

--- a/sheep/sheep.c
+++ b/sheep/sheep.c
@@ -376,6 +376,13 @@ static int wq_peer_parser(const char *s)
 	return 0;
 }
 
+static int wq_reclaim_threads;
+static int wq_reclaim_parser(const char *s)
+{
+	wq_reclaim_threads = atoi(s);
+	return 0;
+}
+
 static int wq_recovery_threads;
 static int wq_recovery_parser(const char *s)
 {
@@ -395,6 +402,7 @@ static struct option_parser wq_parsers[] = {
 	{ "gway=", wq_gway_parser },
 	{ "io=", wq_io_parser },
 	{ "peer=", wq_peer_parser },
+	{ "reclaim=", wq_reclaim_parser },
 	{ "recovery=", wq_recovery_parser },
 	{ "async=", wq_async_parser },
 };
@@ -534,6 +542,13 @@ static int create_work_queues(void)
 		sd_info("peer workqueue is created as dynamic");
 		sys->peer_wqueue = create_work_queue("peer", WQ_DYNAMIC);
 	}
+	if (wq_reclaim_threads) {
+		sd_info("# of threads in reclaim workqueue: %d", wq_reclaim_threads);
+		sys->reclaim_wqueue = create_fixed_work_queue("peer", wq_reclaim_threads);
+	} else {
+		sd_info("reclaim workqueue is created as dynamic");
+		sys->reclaim_wqueue = create_work_queue("reclaim", WQ_DYNAMIC);
+	}
 	if (wq_recovery_threads) {
 		sd_info("# of threads in rw workqueue: %d", wq_recovery_threads);
 		sys->recovery_wqueue = create_fixed_work_queue("rw", wq_recovery_threads);
@@ -553,7 +568,7 @@ static int create_work_queues(void)
 	}
 	if (!sys->gateway_wqueue || !sys->io_wqueue || !sys->recovery_wqueue ||
 	    !sys->deletion_wqueue || !sys->block_wqueue || !sys->md_wqueue ||
-	    !sys->areq_wqueue || !sys->peer_wqueue)
+	    !sys->areq_wqueue || !sys->peer_wqueue || !sys->reclaim_wqueue)
 			return -1;
 
 	util_wq = create_ordered_work_queue("util");

--- a/sheep/sheep.c
+++ b/sheep/sheep.c
@@ -369,6 +369,13 @@ static int wq_io_parser(const char *s)
 	return 0;
 }
 
+static int wq_peer_threads;
+static int wq_peer_parser(const char *s)
+{
+	wq_peer_threads = atoi(s);
+	return 0;
+}
+
 static int wq_recovery_threads;
 static int wq_recovery_parser(const char *s)
 {
@@ -387,6 +394,7 @@ static struct option_parser wq_parsers[] = {
 	{ "net=", wq_net_parser },
 	{ "gway=", wq_gway_parser },
 	{ "io=", wq_io_parser },
+	{ "peer=", wq_peer_parser },
 	{ "recovery=", wq_recovery_parser },
 	{ "async=", wq_async_parser },
 };
@@ -519,6 +527,13 @@ static int create_work_queues(void)
 		sd_info("io workqueue is created as dynamic");
 		sys->io_wqueue = create_work_queue("io", WQ_DYNAMIC);
 	}
+	if (wq_peer_threads) {
+		sd_info("# of threads in peer workqueue: %d", wq_peer_threads);
+		sys->peer_wqueue = create_fixed_work_queue("peer", wq_peer_threads);
+	} else {
+		sd_info("peer workqueue is created as dynamic");
+		sys->peer_wqueue = create_work_queue("peer", WQ_DYNAMIC);
+	}
 	if (wq_recovery_threads) {
 		sd_info("# of threads in rw workqueue: %d", wq_recovery_threads);
 		sys->recovery_wqueue = create_fixed_work_queue("rw", wq_recovery_threads);
@@ -538,7 +553,7 @@ static int create_work_queues(void)
 	}
 	if (!sys->gateway_wqueue || !sys->io_wqueue || !sys->recovery_wqueue ||
 	    !sys->deletion_wqueue || !sys->block_wqueue || !sys->md_wqueue ||
-	    !sys->areq_wqueue)
+	    !sys->areq_wqueue || !sys->peer_wqueue)
 			return -1;
 
 	util_wq = create_ordered_work_queue("util");

--- a/sheep/sheep.c
+++ b/sheep/sheep.c
@@ -390,6 +390,20 @@ static int wq_gway_fwd_parser(const char *s)
 	return 0;
 }
 
+static int wq_remove_threads;
+static int wq_remove_parser(const char *s)
+{
+	wq_remove_threads = atoi(s);
+	return 0;
+}
+
+static int wq_remove_peer_threads;
+static int wq_remove_peer_parser(const char *s)
+{
+	wq_remove_peer_threads = atoi(s);
+	return 0;
+}
+
 static int wq_recovery_threads;
 static int wq_recovery_parser(const char *s)
 {
@@ -411,6 +425,8 @@ static struct option_parser wq_parsers[] = {
 	{ "peer=", wq_peer_parser },
 	{ "reclaim=", wq_reclaim_parser },
 	{ "gway_fwd=", wq_gway_fwd_parser },
+	{ "remove=", wq_remove_parser },
+	{ "remove_peer=", wq_remove_peer_parser },
 	{ "recovery=", wq_recovery_parser },
 	{ "async=", wq_async_parser },
 };
@@ -563,6 +579,20 @@ static int create_work_queues(void)
 	} else {
 		sd_info("gway_fwd workqueue is created as dynamic");
 		sys->gateway_fwd_wqueue = create_work_queue("gway_fwd", WQ_DYNAMIC);
+	}
+	if (wq_remove_threads) {
+		sd_info("# of threads in remove workqueue: %d", wq_remove_threads);
+		sys->remove_wqueue = create_fixed_work_queue("remove", wq_remove_threads);
+	} else {
+		sd_info("remove workqueue is created as dynamic");
+		sys->remove_wqueue = create_work_queue("remove", WQ_DYNAMIC);
+	}
+	if (wq_remove_peer_threads) {
+		sd_info("# of threads in remove_peer workqueue: %d", wq_remove_peer_threads);
+		sys->remove_peer_wqueue = create_fixed_work_queue("remove_peer", wq_remove_peer_threads);
+	} else {
+		sd_info("remove_peer workqueue is created as dynamic");
+		sys->remove_peer_wqueue = create_work_queue("remove_peer", WQ_DYNAMIC);
 	}
 	if (wq_recovery_threads) {
 		sd_info("# of threads in rw workqueue: %d", wq_recovery_threads);

--- a/sheep/sheep_priv.h
+++ b/sheep/sheep_priv.h
@@ -168,6 +168,8 @@ struct system_info {
 	struct work_queue *peer_wqueue;
 	struct work_queue *reclaim_wqueue;
 	struct work_queue *gateway_fwd_wqueue;
+	struct work_queue *remove_wqueue;
+	struct work_queue *remove_peer_wqueue;
 	struct work_queue *deletion_wqueue;
 	struct work_queue *recovery_wqueue;
 	struct work_queue *recovery_notify_wqueue;
@@ -472,7 +474,11 @@ struct recovery_throttling get_recovery(void);
 
 int sd_write_object(uint64_t oid, char *data, unsigned int datalen,
 		    uint64_t offset, bool create);
+int sd_write_object_fwd(uint64_t oid, char *data, unsigned int datalen,
+			uint64_t offset, bool create);
 int sd_read_object(uint64_t oid, char *data, unsigned int datalen,
+		   uint64_t offset);
+int sd_read_object_fwd(uint64_t oid, char *data, unsigned int datalen,
 		   uint64_t offset);
 int sd_remove_object(uint64_t oid);
 int sd_discard_object(uint64_t oid);

--- a/sheep/sheep_priv.h
+++ b/sheep/sheep_priv.h
@@ -169,8 +169,6 @@ struct system_info {
 	struct work_queue *recovery_wqueue;
 	struct work_queue *recovery_notify_wqueue;
 	struct work_queue *block_wqueue;
-	struct work_queue *oc_reclaim_wqueue;
-	struct work_queue *oc_push_wqueue;
 	struct work_queue *md_wqueue;
 	struct work_queue *areq_wqueue;
 #ifdef HAVE_HTTP

--- a/sheep/sheep_priv.h
+++ b/sheep/sheep_priv.h
@@ -165,6 +165,7 @@ struct system_info {
 	struct work_queue *net_wqueue;
 	struct work_queue *gateway_wqueue;
 	struct work_queue *io_wqueue;
+	struct work_queue *peer_wqueue;
 	struct work_queue *deletion_wqueue;
 	struct work_queue *recovery_wqueue;
 	struct work_queue *recovery_notify_wqueue;

--- a/sheep/sheep_priv.h
+++ b/sheep/sheep_priv.h
@@ -166,6 +166,7 @@ struct system_info {
 	struct work_queue *gateway_wqueue;
 	struct work_queue *io_wqueue;
 	struct work_queue *peer_wqueue;
+	struct work_queue *reclaim_wqueue;
 	struct work_queue *deletion_wqueue;
 	struct work_queue *recovery_wqueue;
 	struct work_queue *recovery_notify_wqueue;

--- a/sheep/sheep_priv.h
+++ b/sheep/sheep_priv.h
@@ -167,6 +167,7 @@ struct system_info {
 	struct work_queue *io_wqueue;
 	struct work_queue *peer_wqueue;
 	struct work_queue *reclaim_wqueue;
+	struct work_queue *gateway_fwd_wqueue;
 	struct work_queue *deletion_wqueue;
 	struct work_queue *recovery_wqueue;
 	struct work_queue *recovery_notify_wqueue;


### PR DESCRIPTION
Current sheepdog uses the io workqueue (sys->io_wqueue) for 2 kinds of
requests: peer and local. However, this architecture can cause
deadlock in the fixed workqueue mode because of the schedules like
below:

1. node A receives a request Ra from a client, queue Ra to io_wqueue
   as a peer request
2. node B receives a request Rb from another client, queue Rb to
   io_wqueue as a peer request
3. in node A, Ra forwards the requests to node B
4. in node B, Rb forwards the requests to node A
5. if node A or node B don't have idle workers in io_workqueue, it can
   cause deadlock

This commit avoids the problem by creating a new dedicated workqueue
sys->peer_wqueue for avoiding the problem.

Signed-off-by: Hitoshi Mitake <mitake.hitoshi@lab.ntt.co.jp>

/cc @tmenjo it would be a serious problem, could you check on your side, too?