### PR TITLE
RFC: sheep: cache eventfd for local request in thread local storage

### DIFF
--- a/include/work.h
+++ b/include/work.h
@@ -80,4 +80,11 @@ int sd_thread_create_with_idx(const char *, sd_thread_t *,
 		     void *(*start_routine)(void *), void *);
 int sd_thread_join(sd_thread_t , void **);
 
+struct worker_atexit {
+	void (*f)(void *);
+	void *arg;
+};
+
+int register_worker_atexit(struct worker_atexit*);
+
 #endif


### PR DESCRIPTION
Creating a fd must be serialized because of the minimum available fd
allocation rule of Posix, so current implementation of the local
request is bad for multicore scalability.

Signed-off-by: Hitoshi Mitake <mitake.hitoshi@lab.ntt.co.jp>

/cc @tmenjo I'm not measuring the performance but this change would introduce some difference.