### PR TITLE
[stable-0.9] Revert "sheep: update ledger objects in an asynchronous manner"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## KNOWN ISSUES
+
+### Distributed deadlock
+
+Distributed deadlock tends to occue when many requests causing update
+of reference count (eg: writing to the working VDI whose snapshot has
+been taken; or deleting such a working VDI or its snapshot) come to
+the Sheepdog cluster in parallel and the number of threads handling
+such requests is too small. In such a case, alive as a process, the
+sheep cannot handle some kind of requests at all, such as read, write
+and remove objects.
+
+Workaround: set the number of threads for *gateway* and *io*
+workqueues large enough. It's recommended that you set it to larger
+than twice of *N* for *gateway* and larger than *N* for *io*. Here,
+*N* is the number of VDIs in the cluster copied-on-write or deleted
+in parallel.
+
+See #362 and #368 for more information.
+
 ## 0.9.5 (release candidate)
 
 IMPORTANT CHANGES:
@@ -5,6 +25,10 @@ IMPORTANT CHANGES:
    This is for sheep not to consume a huge amount of memory by
    creating new threads infinitely under heavy load, and to avoid
    being shot by OOM-killer.
+ - Ledger objects are now updated synchronously. This makes it easy
+   for us to estimate the necessary number of threads for avoiding
+   distributed deadlock, in exchange for performance of copy-on-write,
+   including deleting VDI.
  - zk\_control now can purge znodes within 24 hours. It purges znodes
    created before the given threshold. This is useful if tens of
    thousands of znodes are created in a day.
@@ -34,6 +58,7 @@ NEW FEATURE:
    updates an inode object and related ledger objects in an asynchronous
    manner. This improves performance of copy-on-write and dereferencing,
    especially deleting VDIs.
+   **(Note that this feature will be removed in 0.9.5.)**
 
 ## 0.9.3
 

--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@
 #
 
 # bootstrap / init
-m4_define([sheepdog_version], [0.9.5_rc0])
+m4_define([sheepdog_version], [0.9.5_rc1])
 
 m4_define([git_version],
 	m4_esyscmd([git describe --tags --dirty 2> /dev/null | sed 's/^v//' \

--- a/sheep/gateway.c
+++ b/sheep/gateway.c
@@ -582,11 +582,16 @@ static int prepare_obj_refcnt(const struct sd_req *hdr, uint32_t *vids,
  * This function decreases a refcnt of vid_to_data_oid(old_vid, idx) and
  * increases one of vid_to_data_oid(new_vid, idx)
  */
-static void update_obj_refcnt(uint64_t offset, int start,
-			     size_t nr_vids, uint32_t *vids, uint32_t *new_vids,
+static int update_obj_refcnt(const struct sd_req *hdr, uint32_t *vids,
+			     uint32_t *new_vids,
 			     struct generation_reference *refs)
 {
-	int i, ret = SD_RES_SUCCESS;
+	int i, start, ret = SD_RES_SUCCESS;
+	size_t nr_vids = hdr->data_length / sizeof(*vids);
+	uint64_t offset;
+
+	offset = hdr->obj.offset - offsetof(struct sd_inode, data_vdi_id);
+	start = offset / sizeof(*vids);
 
 	for (i = 0; i < nr_vids; i++) {
 		if (vids[i] == 0 || vids[i] == new_vids[i])
@@ -596,7 +601,16 @@ static void update_obj_refcnt(uint64_t offset, int start,
 					   refs[i].generation, refs[i].count);
 		if (ret != SD_RES_SUCCESS)
 			sd_err("fail, %d", ret);
+
+		refs[i].generation = 0;
+		refs[i].count = 0;
 	}
+
+	return sd_write_object(hdr->obj.oid, (char *)refs,
+			       nr_vids * sizeof(*refs),
+			       offsetof(struct sd_inode, gref)
+			       + start * sizeof(*refs),
+			       false);
 }
 
 static bool is_inode_refresh_req(struct request *req)
@@ -647,51 +661,13 @@ int gateway_read_obj(struct request *req)
 	return ret;
 }
 
-struct update_obj_refcnt_work {
-	struct work work;
-
-	uint64_t offset;
-	int start;
-
-	size_t nr_vids;
-	uint32_t *vids, *new_vids;
-
-	struct generation_reference *refs;
-};
-
-static void async_update_obj_refcnt_work(struct work *work)
-{
-	struct update_obj_refcnt_work *w =
-		container_of(work, struct update_obj_refcnt_work, work);
-
-	sd_debug("async update of object reference count start: %p", w);
-	update_obj_refcnt(w->offset, w->start, w->nr_vids, w->vids,
-			  w->new_vids, w->refs);
-}
-
-static void async_update_obj_refcnt_done(struct work *work)
-{
-	struct update_obj_refcnt_work *w =
-		container_of(work, struct update_obj_refcnt_work, work);
-
-	sd_debug("async update of object reference count done: %p", w);
-
-	free(w->vids);
-	free(w->new_vids);
-	free(w->refs);
-
-	free(w);
-}
-
 int gateway_write_obj(struct request *req)
 {
 	uint64_t oid = req->rq.obj.oid;
 	int ret;
 	struct sd_req *hdr = &req->rq;
 	uint32_t *vids = NULL, *new_vids = req->data;
-	struct generation_reference *refs = NULL, *zeroed_refs = NULL;
-	struct update_obj_refcnt_work *refcnt_work;
-	size_t nr_vids = hdr->data_length / sizeof(*vids);
+	struct generation_reference *refs = NULL;
 
 	if ((req->rq.flags & SD_FLAG_CMD_TGT) &&
 	    is_refresh_required(oid_to_vid(oid))) {
@@ -707,12 +683,13 @@ int gateway_write_obj(struct request *req)
 
 
 	if (is_data_vid_update(hdr)) {
+		size_t nr_vids = hdr->data_length / sizeof(*vids);
+
 		invalidate_other_nodes(oid_to_vid(oid));
 
 		/* read the previous vids to discard their references later */
 		vids = xzalloc(sizeof(*vids) * nr_vids);
 		refs = xzalloc(sizeof(*refs) * nr_vids);
-		zeroed_refs = xcalloc(sizeof(*zeroed_refs), nr_vids);
 		ret = prepare_obj_refcnt(hdr, vids, refs);
 		if (ret != SD_RES_SUCCESS)
 			goto out;
@@ -723,50 +700,13 @@ int gateway_write_obj(struct request *req)
 		goto out;
 
 	if (is_data_vid_update(hdr)) {
-		uint64_t offset;
-		int start;
-
-		offset = hdr->obj.offset
-			- offsetof(struct sd_inode, data_vdi_id);
-		start = offset / sizeof(*vids);
-
 		sd_debug("update reference counts, %016" PRIx64, hdr->obj.oid);
-
-		ret = sd_write_object(hdr->obj.oid, (char *)zeroed_refs,
-				      nr_vids * sizeof(*zeroed_refs),
-				      offsetof(struct sd_inode, gref)
-				      + start * sizeof(*zeroed_refs), false);
-		if (ret != SD_RES_SUCCESS) {
-			sd_err("updating reference count of inode object %016"
-			       PRIx64 " failed: %s", hdr->obj.oid,
-			       sd_strerror(ret));
-
-			goto out;
-		}
-
-		sd_debug("update ledger objects of %016"PRIx64, hdr->obj.oid);
-		refcnt_work = xzalloc(sizeof(*refcnt_work));
-
-		refcnt_work->vids = vids;
-		refcnt_work->refs = refs;
-		refcnt_work->nr_vids = nr_vids;
-		refcnt_work->new_vids = xcalloc(hdr->data_length,
-						sizeof(uint32_t));
-		memcpy(refcnt_work->new_vids, new_vids, hdr->data_length);
-
-		refcnt_work->offset = offset;
-		refcnt_work->start = start;
-
-
-		refcnt_work->work.fn = async_update_obj_refcnt_work;
-		refcnt_work->work.done = async_update_obj_refcnt_done;
-
-		queue_work(sys->io_wqueue, &refcnt_work->work);
+		update_obj_refcnt(hdr, vids, new_vids, refs);
 	}
-
 out:
-	free(zeroed_refs);
 
+	free(vids);
+	free(refs);
 	return ret;
 }
 


### PR DESCRIPTION
**Please do not merge this PR yet.**

@mitake May I have a request for your comments?

-----

As mentioned in #362, there is a risk of deadlock in the stable-0.9 branch. We can mitigate (or may remove) the risk by increasing the maximum number of threads for workqueues enough. However, it is hard to forecast the behavior of parallel execution of (1) and (2) below, making it difficult to estimate the number of threads:

* (1) gateway_write_object (run in a "gateway" thread) to update the data_vdi_id field of an inode, causing update of reference count

* (2) async_update_obj_refcnt_work (run in an "io" thread) to update reference count, following 1)

This commit lets the two above run in serial in a "gateway" thread. Note that the (2) is now update_obj_refcnt.

This reverts commit 796c88df19e32a6a83a6ba54f2b17b03e166b3d2.

Signed-off-by: Takashi Menjo &lt;menjo.takashi@lab.ntt.co.jp&gt;
