### PR TITLE
sheep: clean-up duplicated or unused code

### DIFF
--- a/sheep/sheep_priv.h
+++ b/sheep/sheep_priv.h
@@ -481,7 +481,6 @@ int sd_read_object(uint64_t oid, char *data, unsigned int datalen,
 int sd_read_object_fwd(uint64_t oid, char *data, unsigned int datalen,
 		   uint64_t offset);
 int sd_remove_object(uint64_t oid);
-int sd_discard_object(uint64_t oid);
 int sd_dec_object_refcnt(uint64_t data_oid, uint32_t generation,
 			 uint32_t refcnt);
 

--- a/sheep/store/common.c
+++ b/sheep/store/common.c
@@ -541,22 +541,6 @@ int sd_remove_object(uint64_t oid)
 	return ret;
 }
 
-int sd_discard_object(uint64_t oid)
-{
-	int ret;
-	struct sd_req hdr;
-
-	sd_init_req(&hdr, SD_OP_DISCARD_OBJ);
-	hdr.obj.oid = oid;
-
-	ret = exec_local_req(&hdr, NULL);
-	if (ret != SD_RES_SUCCESS)
-		sd_err("Failed to discard data obj %"PRIu64" %s", oid,
-		       sd_strerror(ret));
-
-	return ret;
-}
-
 int sd_dec_object_refcnt(uint64_t data_oid, uint32_t generation,
 			 uint32_t refcnt)
 {


### PR DESCRIPTION
This PR ...
* rewrites duplicated code in gateway_handle_cow() with sd_{read,write}_object_fwd.
* removes sd_discard_object() because no one calls it.
