### PR TITLE
Fix "make dist" error related to cmock.c and unity.c

### DIFF
--- a/tests/unit/lib/Makefile.am
+++ b/tests/unit/lib/Makefile.am
@@ -18,22 +18,22 @@ LIBS			= -pthread -lm					\
 			  @CHECK_LIBS@
 
 test_util_SOURCES	= test_util.c lib/util.c		\
-			  ../mocks/Mocklogger.c				\
-			  cmock.c unity.c
+			  ../mocks/Mocklogger.c
+nodist_test_util_SOURCES = cmock.c unity.c
 
-test_work_SOURCES	= test_work.c lib/work.c		\
-			  unity.c
+test_work_SOURCES	= test_work.c lib/work.c
+nodist_test_work_SOURCES = unity.c
 
 test_punchhole_SOURCES	= test_punchhole.c				\
 			  lib/util.c				\
-			  ../mocks/Mocklogger.c				\
-			  cmock.c unity.c
+			  ../mocks/Mocklogger.c
+nodist_test_punchhole_SOURCES = cmock.c unity.c
 
 test_atomic_create_and_write_SOURCES =					\
 			  test_atomic_create_and_write.c		\
 			  lib/common.c				\
-			  ../mocks/Mocklogger.c				\
-			  cmock.c unity.c
+			  ../mocks/Mocklogger.c
+nodist_test_atomic_create_and_write_SOURCES = cmock.c unity.c
 
 clean-local:
 	rm -f lib.info

--- a/tests/unit/sheep/Makefile.am
+++ b/tests/unit/sheep/Makefile.am
@@ -19,7 +19,8 @@ LIBS			= $(top_srcdir)/lib/libsd.a		\
 			  @CHECK_LIBS@
 
 test_vdi_SOURCES	= test_vdi.c sheep/vdi.c mock_sheep.c mock_store.c		\
-			  mock_request.c unity.c
+			  mock_request.c
+nodist_test_vdi_SOURCES = unity.c
 
 test_cluster_driver_SOURCES	= mock_sheep.c mock_group.c		\
 				  sheep/cluster/local.c	\
@@ -46,8 +47,8 @@ test_group_SOURCES	= test_group.c sheep/group.c \
 				sheep/recovery.c \
 				sheep/gateway.c \
 				sheep/object_list_cache.c \
-				sheep/migrate.c \
-				cmock.c unity.c
+				sheep/migrate.c
+nodist_test_group_SOURCES = cmock.c unity.c
 
 test_recovery_SOURCES   = test_recovery.c sheep/recovery.c \
                 sheep/ops.c \
@@ -60,8 +61,8 @@ test_recovery_SOURCES   = test_recovery.c sheep/recovery.c \
                 sheep/group.c \
                 sheep/gateway.c \
                 sheep/object_list_cache.c \
-                sheep/migrate.c \
-                cmock.c unity.c
+                sheep/migrate.c
+nodist_test_recovery_SOURCES = cmock.c unity.c
 
 clean-local:
 	rm -f sheep.info


### PR DESCRIPTION
The "make dist" (and other targets depending on it such as "make rpm") has tried to put cmock.c and unity.c in dist but failed in a case of not fetching submodules.

This commit removes them two files from dist by "nodist_" prefix.

Signed-off-by: Takashi Menjo &lt;menjo.takashi@lab.ntt.co.jp&gt;