### PR TITLE
sheep: cancel recovery if failed to fetch object list

### DIFF
--- a/include/internal_proto.h
+++ b/include/internal_proto.h
@@ -326,6 +326,7 @@ enum rw_state {
 	RW_PREPARE_LIST, /* the recovery thread is preparing object list */
 	RW_RECOVER_OBJ, /* the thread is recovering objects */
 	RW_NOTIFY_COMPLETION, /* the thread is notifying recovery completion */
+	RW_CANCELED, /* recovery canceled; no recovery thread is running */
 };
 
 struct recovery_state {


### PR DESCRIPTION
At first stage of recovery, each sheep node sends GET_OBJ_LIST request to all other nodes in the cluster to prepare a list of the objects which should be recovered. The list can be incomplete if any of the requests failed. In such a case, the node should not send COMPLETE_RECOVERY notification to the cluster, or the cluster can lose some objects when all the nodes send that notification.

This commit resolves such an issue by "canceling" recovery, instead of "finishing" it, when any of the GET_OBJ_LIST requests failed. Once the recovery in a sheep cancelled, that sheep never send
COMPLETE_RECOVERY until another epoch-lifting recovery is started then completed. It also sends a DISABLE_RECOVER operation to the cluster to pause ongoing recovery in other nodes.

This commit also fixes #363.

Signed-off-by: Takashi Menjo &lt;menjo.takashi@lab.ntt.co.jp&gt;