### PR TITLE
rpm: give the default values to undefined macros.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -62,25 +62,13 @@ RPMBUILDOPTS = --define "_sourcedir $(abs_builddir)" \
 		--define "_srcrpmdir $(abs_builddir)" \
 		--define "_rpmdir $(abs_builddir)"
 
-RPMBUILD_CONFIG_OPTS =
-RPMBUILD_REQ_OPTS =
-RPMBUILD_BUILD_REQ_OPTS =
-
 if BUILD_ZOOKEEPER
 RPMBUILDOPTS += --define "_have_zookeeper 1"
-RPMBUILD_CONFIG_OPTS += --enable-zookeeper
-RPMBUILD_BUILD_REQ_OPTS += zookeeper-native
 endif
 
 if BUILD_SHEEPFS
-RPMBUILD_CONFIG_OPTS += --enable-sheepfs
-RPMBUILD_REQ_OPTS += fuse
-RPMBUILD_BUILD_REQ_OPTS += fuse-devel
+RPMBUILDOPTS += --define "_have_fuse 1"
 endif
-
-RPMBUILDOPTS += --define "_configopts $(RPMBUILD_CONFIG_OPTS)"
-RPMBUILDOPTS += --define "_requires $(RPMBUILD_REQ_OPTS)"
-RPMBUILDOPTS += --define "_buildrequires $(RPMBUILD_BUILD_REQ_OPTS)"
 
 $(TARFILE):
 	$(MAKE) dist

--- a/sheepdog.spec.in
+++ b/sheepdog.spec.in
@@ -6,8 +6,8 @@ Version: @version@
 Release: 1%{?dist}
 License: GPLv2 and GPLv2+
 Group: System Environment/Base
-URL: http://www.osrg.net/sheepdog
-Source0: http://downloads.sourceforge.net/project/sheepdog/%{name}/%{version}/%{name}-%{version}.tar.gz
+URL: http://sheepdog.github.io/sheepdog
+Source0: https://github.com/sheepdog/%{name}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 
 # Runtime bits
 Requires: corosync %{_requires}

--- a/sheepdog.spec.in
+++ b/sheepdog.spec.in
@@ -1,4 +1,15 @@
+# Define options
 %define use_systemd (0%{?fedora} && 0%{?fedora} >= 18) || (0%{?rhel} && 0%{?rhel} >= 7)
+%define enable_fuse %{?_have_fuse}%{!?_have_fuse:0}
+%define enable_zookeeper %{?_have_zookeeper}%{!?_have_zookeeper:0}
+
+# Configure args
+%if 0%{?enable_fuse} == 1
+%define fuse_configure_args $(echo "--enable-sheepfs")
+%endif
+%if 0%{?enable_zookeeper} == 1
+%define zookeeper_configure_args $(echo "--enable-zookeeper")
+%endif
 
 Name: sheepdog
 Summary: The Sheepdog Distributed Storage System for QEMU
@@ -10,10 +21,12 @@ URL: http://sheepdog.github.io/sheepdog
 Source0: https://github.com/sheepdog/%{name}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 
 # Runtime bits
-Requires: corosync %{_requires}
+Requires: corosync
+%if 0%{enable_fuse}
+Requires: fuse
+%endif
 %if %{use_systemd}
 Requires: systemd
-BuildRequires: systemd-units
 %else
 Requires(post): chkconfig
 Requires(preun): chkconfig
@@ -22,7 +35,16 @@ Requires(preun): initscripts
 
 # Build bits
 BuildRequires: autoconf automake
-BuildRequires: corosynclib-devel userspace-rcu-devel %{_buildrequires}
+BuildRequires: corosynclib-devel userspace-rcu-devel
+%if 0%{enable_fuse}
+BuildRequires: fuse-devel
+%endif
+%if 0%{enable_zookeeper}
+BuildRequires: %{_includedir}/zookeeper/zookeeper.h
+%endif
+%if %{use_systemd}
+BuildRequires: systemd-units
+%endif
 
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
@@ -35,7 +57,7 @@ a distributed object storage system for QEMU.
 
 %build
 ./autogen.sh
-%{configure} --with-initddir=%{_initrddir} %{_configopts}
+%{configure} --with-initddir=%{_initrddir} %{fuse_configure_args} %{zookeeper_configure_args}
 
 make %{_smp_mflags}
 
@@ -65,7 +87,6 @@ rm -rf %{buildroot}
 ln -s -f %{_bindir}/dog %{_bindir}/collie
 
 %preun
-
 if [ $1 -eq 0 ] ; then
     %if %use_systemd
     /usr/bin/systemctl --no-reload disable sheepdog.service >/dev/null 2>&1 || :
@@ -92,13 +113,11 @@ fi
 %defattr(-,root,root,-)
 %doc COPYING README INSTALL
 %{_sbindir}/sheep
-%{_sbindir}/sheepfs
 %{_bindir}/dog
 %{_sbindir}/shepherd
 %dir %{_localstatedir}/lib/sheepdog
 %config %{_sysconfdir}/bash_completion.d/dog
 %{_mandir}/man8/sheep.8*
-%{_mandir}/man8/sheepfs.8*
 %{_mandir}/man8/dog.8*
 %dir %{_includedir}/sheepdog
 %{_includedir}/sheepdog/internal.h
@@ -108,7 +127,11 @@ fi
 %{_includedir}/sheepdog/util.h
 %{_libdir}/libsheepdog.la
 %{_libdir}/libsheepdog.so
-%if 0%{_have_zookeeper}
+%if 0%{enable_fuse}
+%{_sbindir}/sheepfs
+%{_mandir}/man8/sheepfs.8*
+%endif
+%if 0%{enable_zookeeper}
 %{_sbindir}/zk_control
 %endif
 %if %{use_systemd}

--- a/sheepdog.spec.in
+++ b/sheepdog.spec.in
@@ -106,7 +106,7 @@ if [ "$1" -ge "1" ] ; then
     /sbin/service sheepdog condrestart >/dev/null 2>&1 || :
     %endif
 else
-    rm -f /usr/sbin/collie
+    unlink /usr/bin/collie
 fi
 
 %files


### PR DESCRIPTION
Hi,

This PR solves some minor problem of spec.

### problems:

The current speepdog.spec created with `make rpm` is incomplete.
This is because it has undefined macros. (that were supposed to be added from Makefile.)

e.g. `%{_have_zookeeper}`, `%{_configopts}` ...

Using undefined macros will fail with `rpmlint` test. and it makes difficult to rebuild from srpm.

### resolution:

Give the default values to undefined macros. and Makefile manages only flags of macros.
So real configure args will defined in the spec. it will in a changeable from flags.
The default value is `%{_have_zookeeper}` , `%{_have_fuse}` are both `0`. (well... it will be overwritten by in Makefile.)

by doing so, we can satisfy the specification of rpm spec.
The confirmation build env is [here](https://gist.github.com/kazuhisya/e36d36f12b2f5bacb14e23e60f2c78e2).

#### other very small fixes:

- The URL pointed to by spec may old, so I was fix it.
- When uninstalling sheepdog it specified the wrong collie path.

---

Signed-off-by: Kazuhisa Hara <khara@sios.com>