### PR TITLE
rpm: build --disable-corosync

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -240,7 +240,7 @@ AM_CONDITIONAL(BUILD_COVERAGE, test x$enable_coverage = xyes)
 
 AC_ARG_ENABLE([corosync],
 	[  --enable-corosync       : build corosync cluster driver ],,
-	[ enable_corosync="yes" ],)
+	[ enable_corosync="yes" ])
 AM_CONDITIONAL(BUILD_COROSYNC, test x$enable_corosync = xyes)
 
 AC_ARG_ENABLE([zookeeper],

--- a/sheepdog.spec.in
+++ b/sheepdog.spec.in
@@ -25,7 +25,9 @@ URL: http://sheepdog.github.io/sheepdog
 Source0: https://github.com/sheepdog/%{name}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 
 # Runtime bits
+%if 0%{?enable_corosync} == 1
 Requires: corosync
+%endif
 %if 0%{enable_fuse}
 Requires: fuse
 %endif
@@ -39,7 +41,10 @@ Requires(preun): initscripts
 
 # Build bits
 BuildRequires: autoconf automake
-BuildRequires: corosynclib-devel userspace-rcu-devel
+BuildRequires: userspace-rcu-devel
+%if 0%{?enable_corosync} == 1
+BuildRequires: corosynclib-devel
+%endif
 %if 0%{enable_fuse}
 BuildRequires: fuse-devel
 %endif


### PR DESCRIPTION
Corosync is a default cluster management backend, 
but it seems that the official recommended is zookeeper.
https://github.com/sheepdog/sheepdog/wiki/Cluster-Management-Backends-and-dual-NIC

We choose zookeeper, so don't want to be annoying about corosync dependency during build/install rpm.