### PR TITLE
script, Makefile: fix of permission and shebang

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -53,7 +53,7 @@ $(SPEC): $(SPEC).in
 	-e "s#@version@#$(VERSION)#g" \
 	-e "s#@date@#$$date#g" \
 	$< > $@-t
-	chmod a-w $@-t
+	chmod a-w,u+w $@-t
 	mv $@-t $@
 
 RPMBUILDOPTS = --define "_sourcedir $(abs_builddir)" \

--- a/script/gen_bash_completion.pl
+++ b/script/gen_bash_completion.pl
@@ -7,7 +7,7 @@ use strict;
 
 my ($program) = @ARGV;
 
-print "#!bash\n";
+print "# dog bash completion script\n";
 print "\n";
 
 open IN, "$program -h |" or die "cannot find $program\n";


### PR DESCRIPTION
This provides a really small fix.

- c7e9136: `.spec` file created by `make rpm` should have owner write permission.
- 70c9b9c: remove shebang from bash_completion.

---

Signed-off-by: Kazuhisa Hara <<khara@sios.com>>