### PR TITLE
(refs#374) rpm: sub-package separation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -53,7 +53,7 @@ $(SPEC): $(SPEC).in
 	-e "s#@version@#$(VERSION)#g" \
 	-e "s#@date@#$$date#g" \
 	$< > $@-t
-	chmod a-w $@-t
+	chmod a-w,u+w $@-t
 	mv $@-t $@
 
 RPMBUILDOPTS = --define "_sourcedir $(abs_builddir)" \

--- a/script/gen_bash_completion.pl
+++ b/script/gen_bash_completion.pl
@@ -7,7 +7,7 @@ use strict;
 
 my ($program) = @ARGV;
 
-print "#!bash\n";
+print "# dog bash completion script\n";
 print "\n";
 
 open IN, "$program -h |" or die "cannot find $program\n";

--- a/sheepdog.spec.in
+++ b/sheepdog.spec.in
@@ -5,20 +5,10 @@
 %define enable_corosync %{?_have_corosync}%{!?_have_corosync:0}
 
 # Configure args
-%if 0%{?enable_fuse} == 1
+%if 0%{?enable_fuse}
 %define fuse_configure_args $(echo "--enable-sheepfs")
 %else
 %define fuse_configure_args $(echo "--disable-sheepfs")
-%endif
-%if 0%{?enable_zookeeper} == 1
-%define zookeeper_configure_args $(echo "--enable-zookeeper")
-%else
-%define zookeeper_configure_args $(echo "--disable-zookeeper")
-%endif
-%if 0%{?enable_corosync} == 1
-%define corosync_configure_args $(echo "--enable-corosync")
-%else
-%define corosync_configure_args $(echo "--disable-corosync") 
 %endif
 
 Name: sheepdog
@@ -31,12 +21,6 @@ URL: http://sheepdog.github.io/sheepdog
 Source0: https://github.com/sheepdog/%{name}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 
 # Runtime bits
-%if 0%{enable_corosync}
-Requires: corosync
-%endif
-%if 0%{enable_fuse}
-Requires: fuse
-%endif
 %if %{use_systemd}
 Requires: systemd
 %else
@@ -48,15 +32,6 @@ Requires(preun): initscripts
 # Build bits
 BuildRequires: autoconf automake libtool
 BuildRequires: userspace-rcu-devel yasm
-%if 0%{enable_corosync}
-BuildRequires: corosynclib-devel
-%endif
-%if 0%{enable_fuse}
-BuildRequires: fuse-devel
-%endif
-%if 0%{enable_zookeeper}
-BuildRequires: %{_includedir}/zookeeper/zookeeper.h
-%endif
 %if %{use_systemd}
 BuildRequires: systemd-units
 %endif
@@ -84,8 +59,33 @@ Requires: %{name}-libs%{?_isa} = %{version}-%{release}
 %description devel
 This package provides the header files for libsheepdog.
 
+# for zookeeper driver
+%if 0%{?enable_zookeeper}
+%package zookeeper
+Summary: ZooKeeper cluster driver for Sheepdog
+Group: Applications/File
+Conflicts: %{name}-corosync
+Requires: %{name}%{?_isa} = %{version}-%{release}
+BuildRequires: %{_includedir}/zookeeper/zookeeper.h
+
+%description zookeeper
+This package provides the ZooKeeper cluster driver for sheepdog.
+%endif
+
+# for corosync driver
+%if 0%{?enable_corosync}
+%package corosync
+Summary: Corosync cluster driver for Sheepdog
+Group: Applications/File
+Conflicts: %{name}-zookeeper
+Requires: %{name}%{?_isa} = %{version}-%{release}
+
+%description corosync
+This package provides the corosync cluster driver for sheepdog.
+%endif
+
 # for sheepfs
-%if 0%{enable_fuse}
+%if 0%{?enable_fuse}
 %package sheepfs
 Summary: FUSE-based pseudo file system for Sheepdog
 Group: Applications/File
@@ -106,44 +106,112 @@ as sheepdog's high reliable storage.
 
 %build
 ./autogen.sh
-%{configure} --with-initddir=%{_initrddir} %{fuse_configure_args} %{zookeeper_configure_args} %{corosync_configure_args}
 
-make %{_smp_mflags}
+## for zookeeper driver
+%if 0%{?enable_zookeeper}
+%{configure} \
+  --with-initddir=%{_initrddir} \
+  --enable-zookeeper \
+  --disable-corosync
+make %{?_smp_mflags}
+%{__mv} %{_builddir}/%{name}-%{version}/sheep/sheep \
+    %{_builddir}/%{name}-%{version}/sheep/sheep.zookeeper
+%{__mv} %{_builddir}/%{name}-%{version}/tools/zk_control \
+    %{_builddir}/%{name}-%{version}/tools/zk_control.zookeeper
+make clean
+%endif
+
+# for corosync driver
+%if 0%{?enable_corosync}
+%{configure} \
+  --with-initddir=%{_initrddir} \
+  --disable-zookeeper \
+  --enable-corosync
+make %{?_smp_mflags}
+%{__mv} %{_builddir}/%{name}-%{version}/sheep/sheep \
+    %{_builddir}/%{name}-%{version}/sheep/sheep.corosync
+make clean
+%endif
+
+# for localonly driver
+%{configure} \
+  --with-initddir=%{_initrddir} \
+  --disable-zookeeper \
+  --disable-corosync \
+  %{fuse_configure_args}
+make %{?_smp_mflags}
+%{__mv} %{_builddir}/%{name}-%{version}/sheep/sheep \
+    %{_builddir}/%{name}-%{version}/sheep/sheep.local
 
 %install
-rm -rf %{buildroot}
+%{__rm} -rf %{buildroot}
 
 make install DESTDIR=%{buildroot}
 
 # drop init file (systemd only)
 %if %{use_systemd}
-rm -f $RPM_BUILD_ROOT%{_initddir}/sheepdog
+%{__rm} -f $RPM_BUILD_ROOT%{_initddir}/sheepdog
 %endif
 
 ## tree fixup
 # drop static libs
-rm -f %{buildroot}%{_libdir}/*.a
+%{__rm} -f %{buildroot}%{_libdir}/*.a
 # drop libtool library file
-rm -f %{buildroot}%{_libdir}/*.la
+%{__rm} -f %{buildroot}%{_libdir}/*.la
+# drop dirty sbin/sheep
+%{__rm} -f %{buildroot}%{_sbindir}/sheep
 
 # install collie command
-ln -s -f dog $RPM_BUILD_ROOT%{_bindir}/collie
+%{__ln_s} -f dog $RPM_BUILD_ROOT%{_bindir}/collie
+
+## install drivers
+# install zookeeper driver
+%if 0%{?enable_zookeeper}
+%{__install} -m755 %{_builddir}/%{name}-%{version}/sheep/sheep.zookeeper \
+    $RPM_BUILD_ROOT%{_sbindir}/sheep.zookeeper
+%{__install} -m755 %{_builddir}/%{name}-%{version}/tools/zk_control.zookeeper \
+    $RPM_BUILD_ROOT%{_sbindir}/zk_control.zookeeper
+%endif
+
+# install corosync driver
+%if 0%{?enable_corosync}
+%{__install} -m755 %{_builddir}/%{name}-%{version}/sheep/sheep.corosync \
+    $RPM_BUILD_ROOT%{_sbindir}/sheep.corosync
+%endif
+
+# install localonly driver
+%{__install} -m755 %{_builddir}/%{name}-%{version}/sheep/sheep.local \
+    $RPM_BUILD_ROOT%{_sbindir}/sheep.local
 
 %clean
-rm -rf %{buildroot}
+%{__rm} -rf %{buildroot}
 
 %post
 %if %{use_systemd}
-/usr/bin/systemctl preset sheepdog.service >/dev/null 2>&1 || :
+%{_bindir}/systemctl preset sheepdog.service >/dev/null 2>&1 || :
 %else
 /sbin/chkconfig --add sheepdog
+%endif
+if [ ! -L %{_sbindir}/sheep ]; then
+    %{__ln_s} -f sheep.local %{_sbindir}/sheep
+fi
+
+%if 0%{?enable_zookeeper}
+%post zookeeper
+%{__ln_s} -f sheep.zookeeper %{_sbindir}/sheep
+%{__ln_s} -f zk_control.zookeeper %{_sbindir}/zk_control
+%endif
+
+%if 0%{?enable_corosync}
+%post corosync
+%{__ln_s} -f sheep.corosync %{_sbindir}/sheep
 %endif
 
 %preun
 if [ $1 -eq 0 ] ; then
-    %if %use_systemd
-    /usr/bin/systemctl --no-reload disable sheepdog.service >/dev/null 2>&1 || :
-    /usr/bin/systemctl stop sheepdog.service >/dev/null 2>&1 || :
+    %if %{use_systemd}
+    %{_bindir}/systemctl --no-reload disable sheepdog.service >/dev/null 2>&1 || :
+    %{_bindir}/systemctl stop sheepdog.service >/dev/null 2>&1 || :
     %else
     /sbin/service sheepdog stop >/dev/null 2>&1
     /sbin/chkconfig --del sheepdog
@@ -152,18 +220,38 @@ fi
 
 %postun
 if [ "$1" -ge "1" ] ; then
-    %if %use_systemd
-    /usr/bin/systemctl daemon-reload >/dev/null 2>&1 || :
-    /usr/bin/systemctl try-restart sheepdog.service >/dev/null 2>&1 || :
+    %if %{use_systemd}
+    %{_bindir}/systemctl daemon-reload >/dev/null 2>&1 || :
+    %{_bindir}/systemctl try-restart sheepdog.service >/dev/null 2>&1 || :
     %else
     /sbin/service sheepdog condrestart >/dev/null 2>&1 || :
     %endif
 fi
+if [ $1 -eq 0 ] && [ -L %{_sbindir}/sheep ] ; then
+    /bin/unlink %{_sbindir}/sheep
+fi
+
+%if 0%{?enable_zookeeper}
+%postun zookeeper
+if [ $1 -eq 0 ] ; then
+    /bin/unlink %{_sbindir}/zk_control
+    if [ ! -L %{_sbindir}/sheep ]; then
+        %{__ln_s} -f sheep.local %{_sbindir}/sheep
+    fi
+fi
+%endif
+
+%if 0%{?enable_corosync}
+%postun corosync
+if [ $1 -eq 0 ] && [ ! -L %{_sbindir}/sheep ]; then
+    %{__ln_s} -f sheep.local %{_sbindir}/sheep
+fi
+%endif
 
 %files
 %defattr(-,root,root,-)
 %doc COPYING README INSTALL
-%{_sbindir}/sheep
+%{_sbindir}/sheep.local
 %{_bindir}/collie
 %{_bindir}/dog
 %{_sbindir}/shepherd
@@ -171,9 +259,6 @@ fi
 %config %{_sysconfdir}/bash_completion.d/dog
 %{_mandir}/man8/sheep.8*
 %{_mandir}/man8/dog.8*
-%if 0%{enable_zookeeper}
-%{_sbindir}/zk_control
-%endif
 %if %{use_systemd}
 %{_unitdir}/sheepdog.service
 %else
@@ -191,9 +276,23 @@ fi
 %dir %{_includedir}/sheepdog
 %{_includedir}/sheepdog/*.h
 
+# for zookeeper driver
+%if 0%{?enable_zookeeper}
+%files zookeeper
+%defattr(-,root,root,-)
+%{_sbindir}/sheep.zookeeper
+%{_sbindir}/zk_control.zookeeper
+%endif
+
+# for corosync driver
+%if 0%{?enable_corosync}
+%files corosync
+%defattr(-,root,root,-)
+%{_sbindir}/sheep.corosync
+%endif
 
 # for sheepfs
-%if 0%{enable_fuse}
+%if 0%{?enable_fuse}
 %files sheepfs
 %defattr(-,root,root,-)
 %{_sbindir}/sheepfs

--- a/sheepdog.spec.in
+++ b/sheepdog.spec.in
@@ -8,15 +8,15 @@
 %if 0%{?enable_fuse} == 1
 %define fuse_configure_args $(echo "--enable-sheepfs")
 %else
-%define fuse_configure_args %{nil}
+%define fuse_configure_args $(echo "--disable-sheepfs")
 %endif
 %if 0%{?enable_zookeeper} == 1
 %define zookeeper_configure_args $(echo "--enable-zookeeper")
 %else
-%define zookeeper_configure_args %{nil}
+%define zookeeper_configure_args $(echo "--disable-zookeeper")
 %endif
 %if 0%{?enable_corosync} == 1
-%define corosync_configure_args %{nil}
+%define corosync_configure_args $(echo "--enable-corosync")
 %else
 %define corosync_configure_args $(echo "--disable-corosync") 
 %endif
@@ -46,8 +46,8 @@ Requires(preun): initscripts
 %endif
 
 # Build bits
-BuildRequires: autoconf automake
-BuildRequires: userspace-rcu-devel
+BuildRequires: autoconf automake libtool
+BuildRequires: userspace-rcu-devel yasm
 %if 0%{enable_corosync}
 BuildRequires: corosynclib-devel
 %endif
@@ -66,6 +66,40 @@ BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 %description
 This package contains the Sheepdog server, and command line tool which offer
 a distributed object storage system for QEMU.
+
+# for libs
+%package libs
+Summary: Shared libraries for Sheepdog
+Group: Applications/File
+
+%description libs
+This package provides the libsheepdog shared library.
+
+# for devel
+%package devel
+Summary: Header files for Sheepdog
+Group: Development/Libraries
+Requires: %{name}-libs%{?_isa} = %{version}-%{release}
+
+%description devel
+This package provides the header files for libsheepdog.
+
+# for sheepfs
+%if 0%{enable_fuse}
+%package sheepfs
+Summary: FUSE-based pseudo file system for Sheepdog
+Group: Applications/File
+Requires: %{name}%{?_isa} = %{version}-%{release}
+Requires: fuse
+BuildRequires: fuse-devel
+
+%description sheepfs
+This package provides the sheepfs.
+
+Sheepfs is a FUSE-based pseudo file system in userland to access both
+sheepdog's internal state (for e.g, cluster info, vdi list) as well
+as sheepdog's high reliable storage.
+%endif
 
 %prep
 %setup -q
@@ -89,6 +123,8 @@ rm -f $RPM_BUILD_ROOT%{_initddir}/sheepdog
 ## tree fixup
 # drop static libs
 rm -f %{buildroot}%{_libdir}/*.a
+# drop libtool library file
+rm -f %{buildroot}%{_libdir}/*.la
 
 # install collie command
 ln -s -f dog $RPM_BUILD_ROOT%{_bindir}/collie
@@ -135,18 +171,6 @@ fi
 %config %{_sysconfdir}/bash_completion.d/dog
 %{_mandir}/man8/sheep.8*
 %{_mandir}/man8/dog.8*
-%dir %{_includedir}/sheepdog
-%{_includedir}/sheepdog/internal.h
-%{_includedir}/sheepdog/list.h
-%{_includedir}/sheepdog/sheepdog.h
-%{_includedir}/sheepdog/sheepdog_proto.h
-%{_includedir}/sheepdog/util.h
-%{_libdir}/libsheepdog.la
-%{_libdir}/libsheepdog.so
-%if 0%{enable_fuse}
-%{_sbindir}/sheepfs
-%{_mandir}/man8/sheepfs.8*
-%endif
 %if 0%{enable_zookeeper}
 %{_sbindir}/zk_control
 %endif
@@ -154,6 +178,26 @@ fi
 %{_unitdir}/sheepdog.service
 %else
 %attr(755,-,-)%config %{_initddir}/sheepdog
+%endif
+
+# for libs
+%files libs
+%defattr(-,root,root,-)
+%{_libdir}/*.so
+
+# for devel
+%files devel
+%defattr(-,root,root,-)
+%dir %{_includedir}/sheepdog
+%{_includedir}/sheepdog/*.h
+
+
+# for sheepfs
+%if 0%{enable_fuse}
+%files sheepfs
+%defattr(-,root,root,-)
+%{_sbindir}/sheepfs
+%{_mandir}/man8/sheepfs.8*
 %endif
 
 %changelog

--- a/sheepdog.spec.in
+++ b/sheepdog.spec.in
@@ -90,6 +90,9 @@ rm -f $RPM_BUILD_ROOT%{_initddir}/sheepdog
 # drop static libs
 rm -f %{buildroot}%{_libdir}/*.a
 
+# install collie command
+ln -s -f dog $RPM_BUILD_ROOT%{_bindir}/collie
+
 %clean
 rm -rf %{buildroot}
 
@@ -99,7 +102,6 @@ rm -rf %{buildroot}
 %else
 /sbin/chkconfig --add sheepdog
 %endif
-ln -s -f %{_bindir}/dog %{_bindir}/collie
 
 %preun
 if [ $1 -eq 0 ] ; then
@@ -120,14 +122,13 @@ if [ "$1" -ge "1" ] ; then
     %else
     /sbin/service sheepdog condrestart >/dev/null 2>&1 || :
     %endif
-else
-    unlink /usr/bin/collie
 fi
 
 %files
 %defattr(-,root,root,-)
 %doc COPYING README INSTALL
 %{_sbindir}/sheep
+%{_bindir}/collie
 %{_bindir}/dog
 %{_sbindir}/shepherd
 %dir %{_localstatedir}/lib/sheepdog


### PR DESCRIPTION
Hi,

This PR is related to issue #374. Can I get reviews and/or opinions?

I implemented `.rpm` subpackages as follows.

1. `sheepdog` : The Sheepdog Distributed Storage System for QEMU (main)
2. `sheepdog-libs` : Shared libraries for Sheepdog
3. `sheepdog-devel` : Header files for Sheepdog
4. `sheepdog-corosync` : Corosync cluster driver for Sheepdog
5. `sheepdog-zookeeper` : ZooKeeper cluster driver for Sheepdog
6. `sheepdog-sheepfs` : FUSE-based pseudo file system for Sheepdog

With this change, `configure` and `make` runs multiple times in `make rpm` depending on the options given. it may not be a little elegant...

How do you think?

(This PR is also include PR #376.)

## Build Matrix

The `.rpm` to be created is determined according to the `configure` options of `make rpm`.

| Condition                 | sheepdog | libs | devel | corosync | zookeeper | sheepfs |
|:--------------------------|:--------:|:----:|:-----:|:--------:|:---------:|:-------:|
| disable all               | yes      | yes  | yes   | no       | no        | no      |
| enable fuse               | yes      | yes  | yes   | no       | no        | **yes** |
| enable corosync           | yes      | yes  | yes   | **yes**  | no        | no      |
| enable zookeeper          | yes      | yes  | yes   | no       | **yes**   | no      |
| enable corosync, fuse     | yes      | yes  | yes   | **yes**  | no        | **yes** |
| enable zookeeper, fuse    | yes      | yes  | yes   | no       | **yes**   | **yes** |
| enable corosync, zk, fuse | yes      | yes  | yes   | **yes**  | **yes**   | **yes** |

* local cluster driver is just included in `sheepdog` package.

## Use Case


e.g. sheepdog with local cluster driver:

```bash
$ sudo yum install sheepdog
```

e.g. sheepdog with ZooKeeper cluster driver:

```bash
$ sudo yum install sheepdog sheepdog-zookeeper
```

e.g. sheepdog with Corosync cluster driver:

```bash
$ sudo yum install sheepdog sheepdog-corosync
```

e.g. sheepdog with local cluster driver and Sheepfs:


```bash
$ sudo yum install sheepdog sheepdog-sheepfs
```

e.g. sheepdog with ZooKeeper/corosync cluster driver and Sheepfs:

```bash
$ sudo yum install sheepdog sheepdog-zookeeper sheepdog-sheepfs
```

```bash
$ sudo yum install sheepdog sheepdog-corosync sheepdog-sheepfs
```

## Test logs

1. The `.rpm` binary created by this change put it [here](https://copr.fedorainfracloud.org/coprs/khara/sheepdog/packages/). \[1]
2. The result of test installation using this `.rpm` is [here](https://gist.github.com/kazuhisya/d5f2b6047a03e0979f9ff047c1bb4db4). \[2].
3. The result of `.rpm` build test is [here](https://gist.github.com/kazuhisya/27809a3ed71e7090b51d53641485f099) \[3].

--

\[1]: https://copr.fedorainfracloud.org/coprs/khara/sheepdog/packages/

\[2]: https://gist.github.com/kazuhisya/d5f2b6047a03e0979f9ff047c1bb4db4

\[3]: https://gist.github.com/kazuhisya/27809a3ed71e7090b51d53641485f099

- [2], [3] have very long detailed logs.