### PR TITLE
script: add a default template to sysconfig

### DIFF
--- a/script/Makefile.am
+++ b/script/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES    = Makefile.in
 
-EXTRA_DIST		= sheepdog.in sheepdog.service.in
+EXTRA_DIST		= sheepdog.in sheepdog.service.in sheepdog.sysconfig
 
 noinst_HEADERS		= checkarch.sh vditest gen_man.pl gen_bash_completion.pl
 

--- a/script/sheepdog.sysconfig
+++ b/script/sheepdog.sysconfig
@@ -1,0 +1,3 @@
+# sheepdog service script configuration file
+# see sheep(8) for details.
+SHEEP_OPTS="--cluster local --log dst=syslog --upgrade /var/lib/sheepdog"

--- a/sheepdog.spec.in
+++ b/sheepdog.spec.in
@@ -164,6 +164,11 @@ make install DESTDIR=%{buildroot}
 # install collie command
 %{__ln_s} -f dog $RPM_BUILD_ROOT%{_bindir}/collie
 
+# install sysconfig template
+%{__mkdir} -p $RPM_BUILD_ROOT%{_sysconfdir}/sysconfig
+%{__install} -m644 %{_builddir}/%{name}-%{version}/script/sheepdog.sysconfig \
+    $RPM_BUILD_ROOT%{_sysconfdir}/sysconfig/sheepdog
+
 ## install drivers
 # install zookeeper driver
 %if 0%{?enable_zookeeper}
@@ -259,6 +264,7 @@ fi
 %config %{_sysconfdir}/bash_completion.d/dog
 %{_mandir}/man8/sheep.8*
 %{_mandir}/man8/dog.8*
+%config %{_sysconfdir}/sysconfig/sheepdog
 %if %{use_systemd}
 %{_unitdir}/sheepdog.service
 %else


### PR DESCRIPTION
Put the template in sysconfig. This make it easier maintaining sheepdog
service settings.

Signed-off-by: Kazuhisa Hara <khara@sios.com>