### PR TITLE
script: fix "Unescaped left brace in regex is deprecated" warnings.

### DIFF
--- a/script/checkpatch.pl
+++ b/script/checkpatch.pl
@@ -2159,8 +2159,8 @@ sub process {
 
 # function brace can't be on same line, except for #defines of do while,
 # or if closed on same line
-		if (($line=~/$Type\s*$Ident\(.*\).*\s{/) and
-		    !($line=~/\#\s*define.*do\s{/) and !($line=~/}/)) {
+		if (($line=~/$Type\s*$Ident\(.*\).*\s\{/) and
+		    !($line=~/\#\s*define.*do\s\{/) and !($line=~/}/)) {
 			ERROR("OPEN_BRACE",
 			      "open brace '{' following function declarations go on the next line\n" . $herecurr);
 		}
@@ -2412,8 +2412,8 @@ sub process {
 		}
 
 #need space before brace following if, while, etc
-		if (($line =~ /\(.*\){/ && $line !~ /\($Type\){/) ||
-		    $line =~ /do{/) {
+		if (($line =~ /\(.*\)\{/ && $line !~ /\($Type\){/) ||
+		    $line =~ /do\{/) {
 			ERROR("SPACING",
 			      "space required before the open brace '{'\n" . $herecurr);
 		}


### PR DESCRIPTION
`checkpatch.pl` uses perl regex which do not escape curly braces. In Perl 5.22 or higher, unescaped left curly braces in a regex are deprecated and will outputted a warning. and this will be an error rather than a warning in future versions (maybe 5.26?).
This change provides suppress above problem.

See also: http://perldoc.perl.org/perl5220delta.html#New-Warnings
(`Unescaped left brace in regex is deprecated, passed through in regex; marked by <-- HERE in m/%s/` section)

Reproducible Env: fedora25

```
$ ./script/checkpatch.pl 0001-test.patch 
Unescaped left brace in regex is deprecated, passed through in regex; marked by <-- HERE in m/\#\s*define.*do\s{ <-- HERE / at ./script/checkpatch.pl line 2163.
Unescaped left brace in regex is deprecated, passed through in regex; marked by <-- HERE in m/\(.*\){ <-- HERE / at ./script/checkpatch.pl line 2415.
Unescaped left brace in regex is deprecated, passed through in regex; marked by <-- HERE in m/do{ <-- HERE / at ./script/checkpatch.pl line 2416.
Unescaped left brace in regex is deprecated, passed through in regex; marked by <-- HERE in m/(?^x:
			(?^x:
			(?:(?^:(?:(?^x:
			const|
			__percpu|
			__nocast|
~~ snip ~~
```

```
$ perl -v

This is perl 5, version 24, subversion 1 (v5.24.1) built for x86_64-linux-thread-multi
(with 68 registered patches, see perl -V for more detail)

Copyright 1987-2017, Larry Wall

Perl may be copied only under the terms of either the Artistic License or the
GNU General Public License, which may be found in the Perl 5 source kit.

Complete documentation for Perl, including FAQ lists, should be found on
this system using "man perl" or "perldoc perl".  If you have access to the
Internet, point your browser at http://www.perl.org/, the Perl Home Page.
```

Signed-off-by: Kazuhisa Hara <khara@sios.com>