### PR TITLE
rpm: add rpm BuildRequires for corosync

### DIFF
--- a/sheepdog.spec.in
+++ b/sheepdog.spec.in
@@ -79,6 +79,8 @@ Summary: Corosync cluster driver for Sheepdog
 Group: Applications/File
 Conflicts: %{name}-zookeeper
 Requires: %{name}%{?_isa} = %{version}-%{release}
+BuildRequires: %{_includedir}/corosync/cpg.h
+BuildRequires: %{_includedir}/corosync/cfg.h
 
 %description corosync
 This package provides the corosync cluster driver for sheepdog.


### PR DESCRIPTION
In order to compile `sheep` binary with corosync enabled,
`cpg.h` and `cfg.h` are required additionally.

https://github.com/sheepdog/sheepdog/blob/master/sheep/cluster/corosync.c#L14-L15

Signed-off-by: Kazuhisa Hara <khara@sios.com>