### PR TITLE
tests: added support for testing with CentOS 7.x

### DIFF
--- a/tests/functional/114
+++ b/tests/functional/114
@@ -14,11 +14,22 @@ fi
 
 function _listFiles
 {
+	# Workaround for SELinux enabled environment.
+	# If SELinux is not disabled (enforcing or permissive),
+	# SELinux uses 1 block. see xattr(7) for details.
+	extra_blocksize=0
+	if [ -e /etc/redhat-release ] && [ `getenforce` != Disabled ]; then
+		extra_blocksize=`tune2fs -l ${1}.img |grep "Block size" | tr -s " "| cut -d " " -f 3`
+	fi
+
 	for i in "$@" ; do
+		# Remove extra block size amount from calculation. If SELinux
+		# is disabled (or not installed) , it is 0, if enabled, it is
+		# remove for one block size.
 		stat -c "%n %b %B %s" "$i"/* |\
-		awk '{print $1,$2*$3,$4;}' |\
-		sort |\
-		_filter_store
+			awk '{print $1,$2*$3-'${extra_blocksize}',$4;}' |\
+			sort |\
+			_filter_store
 	done
 }
 

--- a/tests/script/exec_unit
+++ b/tests/script/exec_unit
@@ -12,7 +12,14 @@ set_up() {
   rm -rf ./tests/unit/cmock
   git submodule update --init ./tests/unit/cmock
 
-  sudo /usr/share/zookeeper/bin/zkServer.sh restart
+  if [ -e /usr/share/zookeeper/bin/zkServer.sh ]; then
+    sudo /usr/share/zookeeper/bin/zkServer.sh restart
+  elif [ -e /usr/lib/zookeeper/bin/zkServer.sh ]; then
+    sudo /usr/lib/zookeeper/bin/zkServer.sh restart
+  else
+    echo "zkServer.sh command is not found"
+    return 1
+  fi
 }
 
 exec_unit() {

--- a/tests/script/prepare_for_test
+++ b/tests/script/prepare_for_test
@@ -2,28 +2,79 @@
 set -xueo pipefail
 export LANG=C LC_ALL=C
 
+check_dist() {
+  if [ -e /etc/debian_version ] || [ -e /etc/debian_release ]; then
+    # Debian or Ubuntu
+    echo "deb"
+
+  elif [ -e /etc/redhat-release ]; then
+    # RHEL or CentOS
+    EL_MAJOR=`cat /etc/rpm/macros.dist |grep rhel | cut -d " " -f 2`
+    if [ ${EL_MAJOR} -eq 7 ]; then
+      echo "el7"
+    else
+      # For now it supports to CentOS7 only
+      echo "unsupported"
+    fi
+
+  else
+    # Other
+    echo "unsupported"
+  fi
+}
+
 prepare() {
-  sudo apt-get update
-  sudo apt-get --quiet -y install \
-    git pkg-config make autoconf libtool yasm liburcu-dev libzookeeper-mt-dev check python zookeeper xfsprogs bc gcc g++
+  if [ ${dist} = "deb" ]; then
+    sudo apt-get update
+    sudo apt-get --quiet -y install \
+      git pkg-config make autoconf libtool yasm liburcu-dev libzookeeper-mt-dev check python zookeeper xfsprogs bc gcc g++
+
+  elif [ ${dist} = "el7" ]; then
+    # epel and bigtop (zookeeper) repo for el7
+    sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+    sudo curl -L -o /etc/yum.repos.d/bigtop.repo http://www.apache.org/dist/bigtop/bigtop-1.1.0/repos/centos7/bigtop.repo
+
+    sudo yum install -y kernel-devel-`uname -r` kernel-headers-`uname -r` \
+      autoconf automake bc check check-devel gcc gcc-c++ git libtool lsof \
+      make net-tools userspace-rcu userspace-rcu-devel yasm yasm-devel \
+      fuse fuse-devel corosync corosynclib corosynclib-devel \
+      zookeeper zookeeper-native zookeeper-server java-1.8.0-openjdk-headless
+  else
+
+    echo "unsupported distribution"
+    return 1
+  fi
 }
 
 build_qemu() {
-  sudo apt-get --quiet -y install zlib1g-dev libglib2.0-dev libpixman-1-dev
-  cd /tmp
-  if [ ! -d qemu ] ; then
-    git clone "${QEMU_GITREPO:-git://git.qemu-project.org/qemu.git}"
+  if [ ${dist} = "deb" ]; then
+    sudo apt-get --quiet -y install zlib1g-dev libglib2.0-dev libpixman-1-dev
+    cd /tmp
+    if [ ! -d qemu ]; then
+      git clone "${QEMU_GITREPO:-git://git.qemu-project.org/qemu.git}"
+    fi
+    cd qemu
+    git checkout -b v2.5.1.1 v2.5.1.1
+    ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var \
+      --target-list=x86_64-softmmu
+    make
+    sudo make install
+    cd ~
+
+  elif [ ${dist} = "el7" ]; then
+    # CentOS Virt-SIG provides qemu with the sheepdog enabled.
+    sudo yum install -y centos-release-qemu-ev
+    sudo yum install -y qemu-kvm-ev qemu-img-ev
+
+  else
+    echo "unsupported distribution"
+    return 1
   fi
-  cd qemu
-  git checkout -b v2.5.1.1 v2.5.1.1
-  ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var \
-    --target-list=x86_64-softmmu
-  make
-  sudo make install
-  cd ~
+
   qemu-io -V
 }
 
 #main
+dist=`check_dist`
 prepare
 build_qemu


### PR DESCRIPTION
refs: #395

- 43f8125: tests/script/* : added support for testing with CentOS 7.x 
    - This change provides support for the testing scripts with CentOS 7.x
    - It has the following features:
        - Modify the commands path depending on distributions
        - Modify the package to be prepared depending on distributions
        - Use qemu-io (is enabled sheepdog) prepared by [CentOS Virt-SIG](https://wiki.centos.org/SpecialInterestGroup/Virtualization)


- 340e421: tests/functional/114 : fix functional 114 to take into account the block of SELinux.
    - If SELinux is not `disabled` (`enforcing` or `permissive`), functional test No.114 will fail.
    - This is because, a single block for SELinux's attribute is added to the `%b * %B` of stat command output, so the output result is different from the SELinux disabled environment.
    - This change provides, it will take into account the block of SELinux.


I run tests(`prepare_for_test`, `exec_unit`, `exec_operation` and `exec_functional`) with CentOS7 and Ubuntu Trusty after this change, and confirmed it be succeed.