### PR TITLE
Makefile: shepherd is only build if it is explicitly enabled

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,7 +15,11 @@ sheepdogsysconfdir	= ${SHEEPDOGCONFDIR}
 
 sheepdogsysconf_DATA	= 
 
-SUBDIRS			= lib dog sheep include script shepherd tools
+SUBDIRS			= lib dog sheep include script tools
+
+if BUILD_SHEPHERD
+SUBDIRS			+= shepherd
+endif
 
 if BUILD_SHEEPFS
 SUBDIRS			+= sheepfs
@@ -66,13 +70,18 @@ if BUILD_ZOOKEEPER
 RPMBUILDOPTS += --define "_have_zookeeper 1"
 endif
 
+if BUILD_COROSYNC
+RPMBUILDOPTS += --define "_have_corosync 1"
+endif
+
+if BUILD_SHEPHERD
+RPMBUILDOPTS += --define "_have_shepherd 1"
+endif
+
 if BUILD_SHEEPFS
 RPMBUILDOPTS += --define "_have_fuse 1"
 endif
 
-if BUILD_COROSYNC
-RPMBUILDOPTS += --define "_have_corosync 1"
-endif
 
 $(TARFILE):
 	$(MAKE) dist

--- a/sheepdog.spec.in
+++ b/sheepdog.spec.in
@@ -3,14 +3,9 @@
 %define enable_fuse %{?_have_fuse}%{!?_have_fuse:0}
 %define enable_zookeeper %{?_have_zookeeper}%{!?_have_zookeeper:0}
 %define enable_corosync %{?_have_corosync}%{!?_have_corosync:0}
+%define enable_shepherd %{?_have_shepherd}%{!?_have_shepherd:0}
 
-# Configure args
-%if 0%{?enable_fuse}
-%define fuse_configure_args $(echo "--enable-sheepfs")
-%else
-%define fuse_configure_args $(echo "--disable-sheepfs")
-%endif
-
+# Main
 Name: sheepdog
 Summary: The Sheepdog Distributed Storage System for QEMU
 Version: @version@
@@ -107,6 +102,25 @@ as sheepdog's high reliable storage.
 %setup -q
 
 %build
+# Configure args
+%if 0%{?enable_fuse}
+%define fuse_configure_args $(echo "--enable-sheepfs")
+%else
+%define fuse_configure_args $(echo "--disable-sheepfs")
+%endif
+
+%if 0%{?enable_shepherd}
+%define shepherd_configure_args $(echo "--enable-shepherd")
+%else
+%define shepherd_configure_args $(echo "--disable-shepherd")
+%endif
+
+%define configure_args $(echo \
+        %{?fuse_configure_args} \
+        %{?shepherd_configure_args} \
+        )
+
+# Autogen
 ./autogen.sh
 
 ## for zookeeper driver
@@ -114,7 +128,8 @@ as sheepdog's high reliable storage.
 %{configure} \
   --with-initddir=%{_initrddir} \
   --enable-zookeeper \
-  --disable-corosync
+  --disable-corosync \
+  %{?configure_args}
 make %{?_smp_mflags}
 %{__mv} %{_builddir}/%{name}-%{version}/sheep/sheep \
     %{_builddir}/%{name}-%{version}/sheep/sheep.zookeeper
@@ -128,7 +143,8 @@ make clean
 %{configure} \
   --with-initddir=%{_initrddir} \
   --disable-zookeeper \
-  --enable-corosync
+  --enable-corosync \
+  %{?configure_args}
 make %{?_smp_mflags}
 %{__mv} %{_builddir}/%{name}-%{version}/sheep/sheep \
     %{_builddir}/%{name}-%{version}/sheep/sheep.corosync
@@ -140,7 +156,7 @@ make clean
   --with-initddir=%{_initrddir} \
   --disable-zookeeper \
   --disable-corosync \
-  %{fuse_configure_args}
+  %{?configure_args}
 make %{?_smp_mflags}
 %{__mv} %{_builddir}/%{name}-%{version}/sheep/sheep \
     %{_builddir}/%{name}-%{version}/sheep/sheep.local
@@ -261,7 +277,6 @@ fi
 %{_sbindir}/sheep.local
 %{_bindir}/collie
 %{_bindir}/dog
-%{_sbindir}/shepherd
 %dir %{_localstatedir}/lib/sheepdog
 %config %{_sysconfdir}/bash_completion.d/dog
 %{_mandir}/man8/sheep.8*
@@ -272,6 +287,10 @@ fi
 %else
 %attr(755,-,-)%config %{_initddir}/sheepdog
 %endif
+%if 0%{?enable_shepherd}
+%{_sbindir}/shepherd
+%endif
+
 
 # for libs
 %files libs


### PR DESCRIPTION
Makefile:
    This change provides shepherd cluster daemon will only build
    if it is explicitly enabled("--enable-shepherd").

rpm:
    Now it can choose to install shepherd binary file synchronously
    with configure options.

Signed-off-by: Kazuhisa Hara <khara@sios.com>