### PR TITLE
sheep/Makefile: nfs/nfs.h should be included in noinst_HEADERS

### DIFF
--- a/sheep/Makefile.am
+++ b/sheep/Makefile.am
@@ -69,7 +69,7 @@ endif
 sheep_DEPENDENCIES	= ../lib/libsd.a
 
 
-noinst_HEADERS		= sheep_priv.h cluster.h http/http.h trace/trace.h
+noinst_HEADERS		= sheep_priv.h cluster.h http/http.h trace/trace.h \
 			  nfs/nfs.h nfs/fs.h
 
 EXTRA_DIST		=


### PR DESCRIPTION
Fix syntax minor corruption of Makefile.
`nfs/nfs.h` (and `nfs/fs.h`) should be included in `noinst_HEADERS`.

Signed-off-by: Kazuhisa Hara <khara@sios.com>