### PR TITLE
rpm: add more configure options

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -82,6 +82,29 @@ if BUILD_SHEEPFS
 RPMBUILDOPTS += --define "_have_fuse 1"
 endif
 
+if BUILD_HTTP
+RPMBUILDOPTS += --define "_have_http 1"
+endif
+
+if BUILD_NFS
+RPMBUILDOPTS += --define "_have_nfs 1"
+endif
+
+if BUILD_DISKVNODES
+RPMBUILDOPTS += --define "_have_diskvnodes 1"
+endif
+
+if BUILD_LTTNG_UST
+RPMBUILDOPTS += --define "_have_lttng_ust 1"
+endif
+
+if BUILD_ACCELIO
+RPMBUILDOPTS += --define "_have_accelio 1"
+endif
+
+if BUILD_TRACE
+RPMBUILDOPTS += --define "_have_trace 1"
+endif
 
 $(TARFILE):
 	$(MAKE) dist

--- a/doc/how_to_upload_packages.rst
+++ b/doc/how_to_upload_packages.rst
@@ -30,7 +30,7 @@ Compile-time dependencies:
 
 2. Make Package
 -----------------
-Here is just an exmple with sheepdog-sheepdog-v1.0-0-gc949903.tar.gz.
+Here is just an exmple with sheepdog-1.0.1.tar.gz.
 
 Replace source-code file which answers your purpose.
 
@@ -46,14 +46,13 @@ Replace source-code file which answers your purpose.
  
  ::
 
-     $ wget https://github.com/sheepdog/sheepdog/tarball/v1.0/sheepdog-sheepdog-v1.0-0-gc949903.tar.gz
-     $ tar zxvf sheepdog-sheepdog-v1.0-0-gc949903.tar.gz
+     $ curl -L https://github.com/sheepdog/sheepdog/archive/v1.0.1.tar.gz| tar zx
 
  3. Set configuration
 
  ::
 
-     $ cd sheepdog-sheepdog-v1.0-0-gc949903
+     $ cd sheepdog-1.0.1
      $ ./autogen.sh
      $ ./configure
 
@@ -72,53 +71,35 @@ Replace source-code file which answers your purpose.
  The deb-package file will be made in the current directory.
 
 - rpm
- 1. Install "rpm-build"
+ 1. Install the required packages
 
  ::
 
      $ sudo yum install rpm-build
-
-
- 2. Make "rpmbuild" directory
-
- ::
-
-     $ cd ~
-     $ mkdir -p rpmbuild/BUILD
-     $ mkdir -p rpmbuild/BUILDROOT
-     $ mkdir -p rpmbuild/RPMS
-     $ mkdir -p rpmbuild/SOURCES
-     $ mkdir -p rpmbuild/SPECS
-     $ mkdir -p rpmbuild/SRPMS
-
- 3. Make spec file
- 
- Make spec file like "Example of rpm spec file" at Reference.
- 
- Then, save it as "sheepdog.spec" in rpmbuild/SPECS.
- 
- 4. Install the required packages
-
- Install the required packages listed on BuildRequires in "sheepdog.spec".
-
- You may need to add "EPEL" repository to install the following packages.
- 
- ::
-
      $ sudo yum install autoconf automake yasm corosynclib-devel userspace-rcu-devel
 
- 5. Download source code
 
- Download the targeted source code and put it in rpmbuild/SOURCES.
-
- 6. Make rpm-package
+ 2. Download & extract source-code file
 
  ::
 
-     $ cd ~/rpmbuild/SPECS
-     $ rpmbuild -ba sheepdog.spec
+     $ curl -L https://github.com/sheepdog/sheepdog/archive/v1.0.1.tar.gz| tar zx
 
- The rpm-package file will be made in rpmbuild/RPMS.
+ 3. Set configuration
+
+ ::
+
+     $ cd sheepdog-1.0.1
+     $ ./autogen.sh
+     $ ./configure
+
+ 4. Make rpm-package
+
+ ::
+
+     $ make rpm
+
+ The rpm-package file will be made in `./x86_64/` .
 
 3. Modify gh-pages
 ------------------
@@ -141,96 +122,3 @@ Replace source-code file which answers your purpose.
 
  Do pull-request to the branch "gh-pages".
 
-Reference
-=========
-
-Example of rpm spec file:
- ::
-
-    Name: sheepdog-sheepdog
-    Summary: The Sheepdog Distributed Storage System for QEMU
-    Version: c949903
-    Release: 1%{?dist}
-    License: GPLv2 and GPLv2+
-    Group: System Environment/Base
-    URL: http://www.osrg.net/sheepdog
-    Source0: https://github.com/sheepdog/sheepdog/tarball/v1.0/sheepdog-sheepdog-v1.0-0-gc949903.tar.gz
-    
-    # Runtime bits
-    Requires: corosync
-    Requires(post): chkconfig
-    Requires(preun): chkconfig
-    Requires(preun): initscripts
-    
-    # Build bits
-    BuildRequires: autoconf automake yasm
-    BuildRequires: corosynclib-devel userspace-rcu-devel
-    
-    BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
-    
-    %description
-    This package contains the Sheepdog server, and command line tool which offer
-    a distributed object storage system for QEMU.
-    
-    %prep
-    %setup -q
-    
-    %build
-    ./autogen.sh
-    %{configure} --with-initddir=%{_initrddir} %{_configopts}
-    
-    make %{_smp_mflags}
-    
-    %install
-    rm -rf %{buildroot}
-    
-    make install DESTDIR=%{buildroot}
-    
-    ## tree fixup
-    # drop static libs
-    rm -f %{buildroot}%{_libdir}/*.a
-    
-    %clean
-    rm -rf %{buildroot}
-    
-    %post
-    /sbin/chkconfig --add sheepdog
-    ln -s -f %{_bindir}/dog %{_bindir}/collie
-    
-    %preun
-    if [ $1 -eq 0 ] ; then
-    	/sbin/service sheepdog stop >/dev/null 2>&1
-    	/sbin/chkconfig --del sheepdog
-    fi
-    
-    %postun
-    if [ "$1" -ge "1" ] ; then
-    	/sbin/service sheepdog condrestart >/dev/null 2>&1 || :
-    else
-    	rm -f /usr/sbin/collie
-    fi
-    
-    %files
-    %defattr(-,root,root,-)
-    %doc COPYING README INSTALL
-    %{_sbindir}/sheep
-    %{_bindir}/dog
-    %{_sbindir}/shepherd
-    %attr(755,-,-)%config %{_initddir}/sheepdog
-    %dir %{_localstatedir}/lib/sheepdog
-    %config %{_sysconfdir}/bash_completion.d/dog
-    %{_mandir}/man8/sheep.8*
-    %{_mandir}/man8/dog.8*
-    %{_prefix}/lib/systemd/system/sheepdog.service
-    %dir %{_includedir}/sheepdog
-    %{_includedir}/sheepdog/internal.h
-    %{_includedir}/sheepdog/list.h
-    %{_includedir}/sheepdog/sheepdog.h
-    %{_includedir}/sheepdog/sheepdog_proto.h
-    %{_includedir}/sheepdog/util.h
-    %{_libdir}/libsheepdog.la
-    %{_libdir}/libsheepdog.so
-    
-    %changelog
-    * Mon Oct 3 2016 Autotools generated version <sheepdog-users@lists.wpkg.org> - v1.0-1.0.0
-    - Autotools generated version

--- a/sheepdog.spec.in
+++ b/sheepdog.spec.in
@@ -1,9 +1,15 @@
 # Define options
-%define use_systemd (0%{?fedora} && 0%{?fedora} >= 18) || (0%{?rhel} && 0%{?rhel} >= 7)
-%define enable_fuse %{?_have_fuse}%{!?_have_fuse:0}
-%define enable_zookeeper %{?_have_zookeeper}%{!?_have_zookeeper:0}
-%define enable_corosync %{?_have_corosync}%{!?_have_corosync:0}
-%define enable_shepherd %{?_have_shepherd}%{!?_have_shepherd:0}
+%define use_systemd       (0%{?fedora} && 0%{?fedora} >= 18) || (0%{?rhel} && 0%{?rhel} >= 7)
+%define enable_fuse       %{?_have_fuse}%{!?_have_fuse:0}
+%define enable_zookeeper  %{?_have_zookeeper}%{!?_have_zookeeper:0}
+%define enable_corosync   %{?_have_corosync}%{!?_have_corosync:0}
+%define enable_shepherd   %{?_have_shepherd}%{!?_have_shepherd:0}
+%define enable_http       %{?_have_http}%{!?_have_http:0}
+%define enable_nfs        %{?_have_nfs}%{!?_have_nfs:0}
+%define enable_diskvnodes %{?_have_diskvnodes}%{!?_have_diskvnodes:0}
+%define enable_lttng_ust  %{?_have_lttng_ust}%{!?_have_lttng_ust:0}
+%define enable_accelio    %{?_have_accelio}%{!?_have_accelio:0}
+%define enable_trace      %{?_have_trace}%{!?_have_trace:0}
 
 # Main
 Name: sheepdog
@@ -23,12 +29,30 @@ Requires(post): chkconfig
 Requires(preun): chkconfig
 Requires(preun): initscripts
 %endif
+%if 0%{?enable_http}
+BuildRequires: fcgi
+%endif
+%if 0%{?enable_lttng_ust}
+BuildRequires: lttng-ust
+%endif
 
 # Build bits
 BuildRequires: autoconf automake libtool
 BuildRequires: userspace-rcu-devel yasm
 %if %{use_systemd}
 BuildRequires: systemd-units
+%endif
+%if 0%{?enable_http}
+BuildRequires: libcurl-devel fcgi-devel
+%endif
+%if 0%{?enable_nfs}
+BuildRequires: %{_includedir}/rpc/rpc.h
+%endif
+%if 0%{?enable_lttng_ust}
+BuildRequires: lttng-ust-devel
+%endif
+%if 0%{?enable_accelio}
+BuildRequires: %{_includedir}/libxio.h
 %endif
 
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
@@ -115,21 +139,58 @@ as sheepdog's high reliable storage.
 %define shepherd_configure_args $(echo "--disable-shepherd")
 %endif
 
-%define configure_args $(echo \
-        %{?fuse_configure_args} \
-        %{?shepherd_configure_args} \
-        )
+%if 0%{?enable_http}
+%define http_configure_args $(echo "--enable-http")
+%else
+%define http_configure_args $(echo "--disable-http")
+%endif
+
+%if 0%{?enable_nfs}
+%define nfs_configure_args $(echo "--enable-nfs")
+%else
+%define nfs_configure_args $(echo "--disable-nfs")
+%endif
+
+%if 0%{?enable_diskvnodes}
+%define diskvnodes_configure_args $(echo "--enable-diskvnodes")
+%else
+%define diskvnodes_configure_args $(echo "--disable-diskvnodes")
+%endif
+
+%if 0%{?enable_lttng_ust}
+%define lttng_ust_configure_args $(echo "--enable-lttng-ust")
+%else
+%define lttng_ust_configure_args $(echo "--disable-lttng-ust")
+%endif
+
+%if 0%{?enable_accelio}
+%define accelio_configure_args $(echo "--enable-accelio")
+%else
+%define accelio_configure_args $(echo "--disable-accelio")
+%endif
+
+%if 0%{?enable_trace}
+%define trace_configure_args $(echo "--enable-trace")
+%else
+%define trace_configure_args $(echo "--disable-trace")
+%endif
 
 # Autogen
 ./autogen.sh
 
-## for zookeeper driver
+# for zookeeper driver
 %if 0%{?enable_zookeeper}
 %{configure} \
   --with-initddir=%{_initrddir} \
   --enable-zookeeper \
   --disable-corosync \
-  %{?configure_args}
+  %{?fuse_configure_args} \
+  %{?http_configure_args} \
+  %{?nfs_configure_args} \
+  %{?diskvnodes_configure_args} \
+  %{?lttng_ust_configure_args} \
+  %{?accelio_configure_args} \
+  %{?trace_configure_args}
 make %{?_smp_mflags}
 %{__mv} %{_builddir}/%{name}-%{version}/sheep/sheep \
     %{_builddir}/%{name}-%{version}/sheep/sheep.zookeeper
@@ -144,7 +205,13 @@ make clean
   --with-initddir=%{_initrddir} \
   --disable-zookeeper \
   --enable-corosync \
-  %{?configure_args}
+  %{?fuse_configure_args} \
+  %{?http_configure_args} \
+  %{?nfs_configure_args} \
+  %{?diskvnodes_configure_args} \
+  %{?lttng_ust_configure_args} \
+  %{?accelio_configure_args} \
+  %{?trace_configure_args}
 make %{?_smp_mflags}
 %{__mv} %{_builddir}/%{name}-%{version}/sheep/sheep \
     %{_builddir}/%{name}-%{version}/sheep/sheep.corosync
@@ -156,7 +223,14 @@ make clean
   --with-initddir=%{_initrddir} \
   --disable-zookeeper \
   --disable-corosync \
-  %{?configure_args}
+  %{?shepherd_configure_args} \
+  %{?fuse_configure_args} \
+  %{?http_configure_args} \
+  %{?nfs_configure_args} \
+  %{?diskvnodes_configure_args} \
+  %{?lttng_ust_configure_args} \
+  %{?accelio_configure_args} \
+  %{?trace_configure_args}
 make %{?_smp_mflags}
 %{__mv} %{_builddir}/%{name}-%{version}/sheep/sheep \
     %{_builddir}/%{name}-%{version}/sheep/sheep.local
@@ -290,7 +364,6 @@ fi
 %if 0%{?enable_shepherd}
 %{_sbindir}/shepherd
 %endif
-
 
 # for libs
 %files libs


### PR DESCRIPTION
9977d37: `rpm: add more configure options`

It can be dealt to more configure options when doing `make rpm`.
For example, the following configs are possible.

```console
$ ./autogen.sh
$ ./configure --enable-corosync --enable-zookeeper \
    --enable-sheepfs --enable-shepherd --enable-http \
    --enable-nfs --enable-diskvnodes --enable-lttng-ust \
    --enable-trace
$ make rpm -j
```

precondition: #400

---

0e0aed7: `doc: modified how_to_upload_packages.rst`

It is no longer necessary to prepare rpm spec.
Currently `make rpm` is available.

Signed-off-by: Kazuhisa Hara <khara@sios.com>