### PR TITLE
Fix typos of docker in case of '/usr/sbin/dog not found'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ADD ./docker/run.sh /root/run.sh
 WORKDIR $SHEEPSRC
 ADD . $SHEEPSRC
 RUN ./autogen.sh
-RUN ./configure && make && make check && make install
+RUN ./configure --prefix=/usr && make && make check && make install
 
 RUN mkdir $SHEEPSTORE
 

--- a/docker/cdog
+++ b/docker/cdog
@@ -3,4 +3,4 @@
 node=${NODE:-n1}
 docker=${DOCKER:-docker}
 
-$docker exec -t $node /usr/sbin/dog $*
+$docker exec -t $node /usr/bin/dog $*


### PR DESCRIPTION
Fix error '/usr/sbin/dog: no such file or directory' when running ./docker/cdog cluster format