### PR TITLE
New fix for issue 380 Correct recovery of I/O NIC

### DIFF
--- a/dog/common.c
+++ b/dog/common.c
@@ -234,6 +234,7 @@ int dog_exec_req(const struct node_id *nid, struct sd_req *hdr, void *buf)
 	struct sockfd *sfd;
 	int ret;
 
+	init_to_connect_list();
 	sfd = sockfd_cache_get(nid);
 	if (!sfd)
 		return -1;

--- a/include/sockfd_cache.h
+++ b/include/sockfd_cache.h
@@ -4,6 +4,10 @@
 #include "internal_proto.h"
 #include "work.h"
 
+enum channel_status {
+	IO,
+	NonIO
+};
 struct sockfd *sockfd_cache_get(const struct node_id *nid);
 void sockfd_cache_put(const struct node_id *nid, struct sockfd *sfd);
 void sockfd_cache_del_node(const struct node_id *nid);
@@ -12,6 +16,7 @@ void sockfd_cache_add(const struct node_id *nid);
 void sockfd_cache_add_group(const struct rb_root *nroot);
 
 int sockfd_init(void);
+int start_node_connectivity_monitor(void);
 
 /* sockfd_cache */
 struct sockfd {

--- a/include/sockfd_cache.h
+++ b/include/sockfd_cache.h
@@ -22,6 +22,7 @@ int start_node_connectivity_monitor(void);
 struct sockfd {
 	int fd;
 	int idx;
+	bool isIO;
 };
 
 #endif	/* SOCKFD_CACHE_H */

--- a/include/sockfd_cache.h
+++ b/include/sockfd_cache.h
@@ -14,6 +14,7 @@ void sockfd_cache_del_node(const struct node_id *nid);
 void sockfd_cache_del(const struct node_id *nid, struct sockfd *sfd);
 void sockfd_cache_add(const struct node_id *nid);
 void sockfd_cache_add_group(const struct rb_root *nroot);
+void init_to_connect_list(void);
 
 int sockfd_init(void);
 int start_node_connectivity_monitor(void);

--- a/sheep/sheep.c
+++ b/sheep/sheep.c
@@ -1169,6 +1169,10 @@ int main(int argc, char **argv)
 		goto cleanup_log;
 	}
 
+	ret = start_node_connectivity_monitor();
+	if (ret)
+		goto cleanup_journal;
+
 	/* We should init trace for work queue before journal init */
 	ret = wq_trace_init();
 	if (ret) {


### PR DESCRIPTION
Signed-off-by: Shien Xie <shien.xie@kaixiangtech.com>

The fix is to let sheepdog switching back to I/O NIC once I/O NIC is back online.
This is how the fix works:
A. We keep 2 sockfd_cache_fd arrays in each sockfd_cache_entry. The first array holds all fds for I/O NIC and the second holds all fds for Non-I/O NIC. When sheepdog starts, all fds in both arrays are -1 and immediately sheepdog pre-connect all fds. When a sheepdog worker thread (ie: gateway thread) needs a fd, it tries to get one from I/O NIC. If failed, it tries to get from the second array. This guarantees I/O NIC is always being chosen first.
B. A dedicated monitor thread is created to monitor all I/O NICs for each node(entry) in sockfd_cache.root. If the thread found an I/O NIC lost connection, it will close all fds in the first array and set their value to -1. This is to prevent worker thread from using broken fds. If that happens, those thread are typically blocked at network I/O system calls for a long time.
C. Once the monitor thread find the I/O NIC connection is back online, the thread will reconnect all fds in the first array for I/O NIC.
D. The number of fds in both arrays will be increased at the same time, when watermark of either array has been reached.

Comparing to the fix we submitted in April, this fix
1. restrict the changes in sockfd_cache.c. By doing this, functions outside sockfd_cache.c will not be affected. The previous fix we submitted requires other programmers remember the status of the IO ports, which is not very good.
2. use one single thread to detect IO ports for all nodes. The previous change requires a thread for each node.
3. separate sockfd_cache_fd into two arrays and pre-connect all fds in those two arrays. The purposes for this design is to decrease the chance that worker threads blocked in I/O operations for broken network connection and hence, improve the performance. With this design, conceptually, there will be no "short" fds. All fds are "long" fds. None-IO ports can be used if no IO ports are available. If there is no network problem, we don't close any fds.

We tested the fix with a sheepdog cluster of 24 servers.

Link to patch:
https://github.com/sheepdog/sheepdog/pull/406.patch