### PR TITLE
issue 408: Imbalanced storage utilization among multiple disks

### DIFF
--- a/sheep/store/md.c
+++ b/sheep/store/md.c
@@ -13,7 +13,7 @@
 
 #include "sheep_priv.h"
 
-#define MD_VDISK_SIZE ((uint64_t)1*1024*1024*1024) /* 1G */
+#define MD_VDISK_SIZE ((uint64_t)1*1024*1024*16) /* 16M */
 
 #define NONE_EXIST_PATH "/all/disks/are/broken/,ps/əʌo7/!"
 


### PR DESCRIPTION
Signed-off-by: Shien Xie <shien.xie@kaixiangtech.com>

The positions calculated by hash functions are not evenly spread on the ring. The situation will be worsen if the positions are hashed twice. For example, if the node has multiple disks and imbalance among disks is worse than imbalance among nodes.

The solution is to reduce the size of vdisk from 1G to 16M. The following is the result. Comparing this to the result described in the issue 408, the imbalance problem is greatly relieved. Test shows performance is also increased around 3%~5%, perhaps because the load is more evenly spreaded.

Test result: 16M vdisk size
Node 0:
0      417 GB  199 GB  218 GB   47%    /sheep/disk0
1      417 GB  198 GB  219 GB   47%    /sheep/disk1
2      417 GB  194 GB  223 GB   46%    /sheep/disk2
3      417 GB  194 GB  224 GB   46%    /sheep/disk3
Node 1:
0      417 GB  158 GB  259 GB   37%    /sheep/disk0
1      417 GB  157 GB  260 GB   37%    /sheep/disk1
2      417 GB  168 GB  249 GB   40%    /sheep/disk2
3      417 GB  161 GB  256 GB   38%    /sheep/disk3
Node 2:
0      417 GB  210 GB  207 GB   50%    /sheep/disk0
1      417 GB  192 GB  225 GB   46%    /sheep/disk1
2      417 GB  187 GB  230 GB   44%    /sheep/disk2
3      417 GB  201 GB  217 GB   48%    /sheep/disk3
Node 3:
0      417 GB  181 GB  236 GB   43%    /sheep/disk0
1      417 GB  185 GB  232 GB   44%    /sheep/disk1
2      417 GB  191 GB  226 GB   45%    /sheep/disk2
3      417 GB  191 GB  226 GB   45%    /sheep/disk3
Node 4:
0      417 GB  198 GB  219 GB   47%    /sheep/disk0
1      417 GB  194 GB  223 GB   46%    /sheep/disk1
2      417 GB  186 GB  231 GB   44%    /sheep/disk2
3      417 GB  180 GB  237 GB   43%    /sheep/disk3
Node 5:
0      417 GB  223 GB  194 GB   53%    /sheep/disk0
1      417 GB  223 GB  194 GB   53%    /sheep/disk1
2      417 GB  209 GB  208 GB   50%    /sheep/disk2
3      417 GB  208 GB  209 GB   49%    /sheep/disk3
Node 6:
0      417 GB  183 GB  235 GB   43%    /sheep/disk0
1      417 GB  178 GB  239 GB   42%    /sheep/disk1
2      417 GB  168 GB  249 GB   40%    /sheep/disk2
3      417 GB  165 GB  252 GB   39%    /sheep/disk3
Node 7:
0      417 GB  164 GB  253 GB   39%    /sheep/disk0
1      417 GB  173 GB  244 GB   41%    /sheep/disk1
2      417 GB  167 GB  250 GB   40%    /sheep/disk2
3      417 GB  176 GB  241 GB   42%    /sheep/disk3
Node 8:
0      417 GB  196 GB  221 GB   46%    /sheep/disk0
1      417 GB  198 GB  220 GB   47%    /sheep/disk1
2      417 GB  192 GB  225 GB   45%    /sheep/disk2
3      417 GB  195 GB  222 GB   46%    /sheep/disk3
Node 9:
0      417 GB  237 GB  180 GB   56%    /sheep/disk0
1      417 GB  232 GB  185 GB   55%    /sheep/disk1
2      417 GB  236 GB  181 GB   56%    /sheep/disk2
3      417 GB  259 GB  159 GB   61%    /sheep/disk3
Node 10:
0      417 GB  230 GB  187 GB   55%    /sheep/disk0
1      417 GB  220 GB  197 GB   52%    /sheep/disk1
2      417 GB  205 GB  212 GB   49%    /sheep/disk2
3      417 GB  221 GB  197 GB   52%    /sheep/disk3
Node 11:
0      417 GB  186 GB  231 GB   44%    /sheep/disk0
1      417 GB  188 GB  229 GB   45%    /sheep/disk1
2      417 GB  183 GB  234 GB   43%    /sheep/disk2
3      417 GB  182 GB  236 GB   43%    /sheep/disk3
Node 12:
0      696 GB  299 GB  396 GB   43%    /sheep/disk0
1      696 GB  297 GB  399 GB   42%    /sheep/disk1
2      696 GB  301 GB  395 GB   43%    /sheep/disk2
3      696 GB  305 GB  390 GB   43%    /sheep/disk3
Node 13:
0      696 GB  313 GB  382 GB   45%    /sheep/disk0
1      696 GB  306 GB  390 GB   43%    /sheep/disk1
2      696 GB  305 GB  391 GB   43%    /sheep/disk2
3      696 GB  297 GB  398 GB   42%    /sheep/disk3
Node 14:
0      696 GB  321 GB  375 GB   46%    /sheep/disk0
1      696 GB  311 GB  385 GB   44%    /sheep/disk1
2      696 GB  332 GB  364 GB   47%    /sheep/disk2
3      696 GB  319 GB  377 GB   45%    /sheep/disk3
Node 15:
0      696 GB  344 GB  352 GB   49%    /sheep/disk0
1      696 GB  318 GB  377 GB   45%    /sheep/disk1
2      696 GB  333 GB  363 GB   47%    /sheep/disk2
3      696 GB  329 GB  367 GB   47%    /sheep/disk3
Node 16:
0      696 GB  304 GB  392 GB   43%    /sheep/disk0
1      696 GB  307 GB  388 GB   44%    /sheep/disk1
2      696 GB  301 GB  394 GB   43%    /sheep/disk2
3      696 GB  323 GB  373 GB   46%    /sheep/disk3
Node 17:
0      696 GB  319 GB  377 GB   45%    /sheep/disk0
1      696 GB  316 GB  379 GB   45%    /sheep/disk1
2      696 GB  316 GB  379 GB   45%    /sheep/disk2
3      696 GB  312 GB  384 GB   44%    /sheep/disk3
Node 18:
0      696 GB  344 GB  352 GB   49%    /sheep/disk0
1      696 GB  330 GB  365 GB   47%    /sheep/disk1
2      696 GB  343 GB  352 GB   49%    /sheep/disk2
3      696 GB  355 GB  340 GB   51%    /sheep/disk3
Node 19:
0      696 GB  336 GB  360 GB   48%    /sheep/disk0
1      696 GB  350 GB  346 GB   50%    /sheep/disk1
2      696 GB  334 GB  361 GB   48%    /sheep/disk2
3      696 GB  358 GB  338 GB   51%    /sheep/disk3
Node 20:
0      696 GB  327 GB  368 GB   47%    /sheep/disk0
1      696 GB  353 GB  342 GB   50%    /sheep/disk1
2      696 GB  339 GB  357 GB   48%    /sheep/disk2
3      696 GB  351 GB  344 GB   50%    /sheep/disk3
Node 21:
0      696 GB  294 GB  402 GB   42%    /sheep/disk0
1      696 GB  297 GB  399 GB   42%    /sheep/disk1
2      696 GB  295 GB  400 GB   42%    /sheep/disk2
3      696 GB  292 GB  404 GB   41%    /sheep/disk3
Node 22:
0      696 GB  322 GB  374 GB   46%    /sheep/disk0
1      696 GB  326 GB  370 GB   46%    /sheep/disk1
2      696 GB  321 GB  375 GB   46%    /sheep/disk2
3      696 GB  321 GB  374 GB   46%    /sheep/disk3
Node 23:
0      696 GB  297 GB  398 GB   42%    /sheep/disk0
1      696 GB  270 GB  426 GB   38%    /sheep/disk1
2      696 GB  289 GB  406 GB   41%    /sheep/disk2
3      696 GB  286 GB  410 GB   41%    /sheep/disk3