### PR TITLE
rpm: Fix BuildRequires mismatch

### DIFF
--- a/sheepdog.spec.in
+++ b/sheepdog.spec.in
@@ -30,10 +30,10 @@ Requires(preun): chkconfig
 Requires(preun): initscripts
 %endif
 %if 0%{?enable_http}
-BuildRequires: fcgi
+Requires: fcgi
 %endif
 %if 0%{?enable_lttng_ust}
-BuildRequires: lttng-ust
+Requires: lttng-ust
 %endif
 
 # Build bits


### PR DESCRIPTION
Fixed mismatch between Build-Requires and Install-Requires.

Signed-off-by: Kazuhisa Hara <khara@sios.com>