### PR TITLE
tests: speed up system prepare for test

### DIFF
--- a/tests/script/exec_functional
+++ b/tests/script/exec_functional
@@ -8,7 +8,7 @@ VAR_PATH=/var
 set_up() {
   ./autogen.sh
   ./configure --prefix=$USR_PATH --localstatedir=$VAR_PATH --enable-zookeeper --disable-corosync --enable-unittest
-  make
+  make -j $(nproc)
   sudo make install
 }
 

--- a/tests/script/exec_operation
+++ b/tests/script/exec_operation
@@ -8,7 +8,7 @@ VAR_PATH=/var
 set_up() {
   ./autogen.sh
   ./configure --prefix=$USR_PATH --localstatedir=$VAR_PATH --enable-zookeeper --disable-corosync --enable-unittest
-  make
+  make -j $(nproc)
   sudo make install
 }
 

--- a/tests/script/exec_unit
+++ b/tests/script/exec_unit
@@ -25,7 +25,7 @@ set_up() {
 exec_unit() {
   ./autogen.sh
   ./configure --prefix=$USR_PATH --localstatedir=$VAR_PATH --enable-zookeeper --disable-corosync --enable-unittest
-  make check
+  make check -j $(nproc)
 }
 
 tear_down() {

--- a/tests/script/prepare_for_test
+++ b/tests/script/prepare_for_test
@@ -26,7 +26,7 @@ check_dist() {
 prepare() {
   if [ ${dist} = "deb" ]; then
     sudo apt-get update
-    sudo apt-get --quiet -y install \
+    sudo apt-get --quiet --no-install-recommends -y install \
       git pkg-config make autoconf libtool yasm liburcu-dev libzookeeper-mt-dev check python zookeeper xfsprogs bc gcc g++
 
   elif [ ${dist} = "el7" ]; then
@@ -51,13 +51,17 @@ build_qemu() {
     sudo apt-get --quiet -y install zlib1g-dev libglib2.0-dev libpixman-1-dev
     cd /tmp
     if [ ! -d qemu ]; then
-      git clone "${QEMU_GITREPO:-git://git.qemu-project.org/qemu.git}"
+      if [[ -v QEMU_GITREPO ]] ; then
+          git clone "${QEMU_GITREPO}"
+      else
+          git clone --depth=1 -b v2.5.1.1 git://git.qemu-project.org/qemu.git
+      fi
     fi
     cd qemu
     git checkout -b v2.5.1.1 v2.5.1.1
     ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var \
       --target-list=x86_64-softmmu
-    make
+    make -j $(nproc)
     sudo make install
     cd ~
 


### PR DESCRIPTION
A small hack reduced the preparation time.

- Use multi-core option of `make` (`-j`)
- Use `--no-install-recommends` option of `apt-get`
- Manipulate depth option of `git clone`

---

Especially the preparation time can be shortened.
For example, the result in Travis CI. 
(If you are using many cpu cores machine, it will become more faster.)

| test             | befor   | after   |
|------------------|--------:|--------:|
| prepare_for_test | 217.24  | **159.37**  |
| exec_unit        | 48.33   | 41.37   |
| exec_operation   | 53.75   | 49.43   |
| exec_functional  | 971.23  | 961.66  |
| total            | 1290.55 | 1211.83 |

- Unit: seconds
- CPUs: 2

Signed-off-by: Kazuhisa Hara <khara@sios.com>