### PR TITLE
tests: improve sparse file detection logic of functional 114

### DIFF
--- a/tests/functional/114
+++ b/tests/functional/114
@@ -14,24 +14,13 @@ fi
 
 function _listFiles
 {
-	# Workaround for SELinux enabled environment.
-	# If SELinux is not disabled (enforcing or permissive),
-	# SELinux uses 1 block. see xattr(7) for details.
-	extra_blocksize=0
-	if [ -e /etc/redhat-release ] && [ `getenforce` != Disabled ]; then
-		extra_blocksize=`tune2fs -l ${1}.img |grep "Block size" | tr -s " "| cut -d " " -f 3`
-	fi
-
 	for i in "$@" ; do
-		# Remove extra block size amount from calculation. If SELinux
-		# is disabled (or not installed) , it is 0, if enabled, it is
-		# remove for one block size.
-		stat -c "%n %b %B %s" "$i"/* |\
-			awk '{
-				if ($2*$3-'${extra_blocksize}' == $4) {
-					print $1, "allocated", $4;
+		find "$i"/* -type f -printf "%S\t%p\t%s\n" 2>/dev/null |\
+			gawk '{
+				if ($1 < 1.0) {
+					print $2 " sparse " $3 ;
 				} else {
-					print $1, "sparse", $4;
+					print $2 " allocated " $3 ;
 				}
 			}' |\
 			sort |\


### PR DESCRIPTION
The `find` command can detect sparse files (`%S`)
Also, if just decide whether it is a sparse file or not, it's do not
need to consider the block size for SELinux anymore.

refs #409

Signed-off-by: Kazuhisa Hara <khara@sios.com>

---

This change makes test script will simple.
And although it is very little, but we can expect to speed up.

befor:

```
$ time sudo ./tests/functional/check 114
PLATFORM      -- Linux/x86_64 localhost 3.10.0-514.26.2.el7.x86_64

114  Test md plug and sparse object
Passed all 1 tests

real	0m7.624s
user	0m0.752s
sys	0m1.597s
```

after:

```
$ time sudo ./tests/functional/check 114
PLATFORM      -- Linux/x86_64 localhost 3.10.0-514.26.2.el7.x86_64

114  Test md plug and sparse object
Passed all 1 tests

real	0m6.644s
user	0m0.655s
sys	0m1.480s
```