### PR TITLE
Include missing header file in sbd.h

### DIFF
--- a/sbd/sbd.h
+++ b/sbd/sbd.h
@@ -16,6 +16,7 @@
 #include <linux/kthread.h>
 #include <linux/gfp.h>
 #include <linux/version.h>
+#include <linux/vmalloc.h>
 
 #include "sheepdog_proto.h"
 


### PR DESCRIPTION
Add #include <linux/vmalloc.h> in sbd.h to be able to compile.

Issue and solution reported on github issue #201