### PR TITLE
lib, sheep: remove obsolete valloc() calls

### DIFF
--- a/lib/util.c
+++ b/lib/util.c
@@ -58,11 +58,12 @@ void *xcalloc(size_t nmemb, size_t size)
 	return ret;
 }
 
-/* zeroed memory version of valloc() */
+/* zeroed memory version of posix_memalign() */
 void *xvalloc(size_t size)
 {
-	void *ret = valloc(size);
-	if (unlikely(!ret))
+	void *ret = NULL;
+	int err = posix_memalign((void **)&ret, getpagesize(), size);
+	if (unlikely(err))
 		panic("Out of memory");
 	memset(ret, 0, size);
 	return ret;

--- a/sheep/gateway.c
+++ b/sheep/gateway.c
@@ -75,8 +75,8 @@ static void *init_erasure_buffer(struct request *req, int buf_len)
 	uint64_t tail = round_down(off + len, SD_EC_DATA_STRIPE_SIZE);
 	int ret;
 
-	buf = valloc(buf_len);
-	if(unlikely(!buf))
+	ret = posix_memalign((void **)&buf, getpagesize(), buf_len);
+	if(unlikely(ret))
 		return NULL;
 	memset(buf, 0, buf_len);
 
@@ -905,11 +905,11 @@ static int gateway_handle_cow(struct request *req)
 	uint64_t oid = req->rq.obj.oid;
 	size_t len = get_objsize(oid, get_vdi_object_size(oid_to_vid(oid)));
 	struct sd_req *req_hdr = &req->rq;
-	char *buf;
+	char *buf = NULL;
 	int ret;
 
-	buf = valloc(len);
-	if(unlikely(!buf)) {
+	ret = posix_memalign((void **)&buf, getpagesize(), len);
+	if(unlikely(ret)) {
 		ret = SD_RES_NO_MEM;
 		goto out;
 	}

--- a/sheep/request.c
+++ b/sheep/request.c
@@ -660,9 +660,11 @@ struct request *alloc_request(struct client_info *ci, uint32_t data_length)
 		return NULL;
 
 	if (data_length) {
+		int ret;
+
 		req->data_length = data_length;
-		req->data = valloc(data_length);
-		if (!req->data) {
+		ret = posix_memalign((void **)&req->data, getpagesize(), data_length);
+		if (ret) {
 			free(req);
 			return NULL;
 		}

--- a/sheep/store/plain_store.c
+++ b/sheep/store/plain_store.c
@@ -611,8 +611,8 @@ int default_get_hash(uint64_t oid, uint32_t epoch, uint8_t *sha1)
 	}
 
 	length = get_store_objsize(oid);
-	buf = valloc(length);
-	if (buf == NULL)
+	ret = posix_memalign((void **)&buf, getpagesize(), length);
+	if (ret)
 		return SD_RES_NO_MEM;
 
 	iocb.epoch = epoch;

--- a/sheep/store/tree_store.c
+++ b/sheep/store/tree_store.c
@@ -662,7 +662,7 @@ static int get_object_path(uint64_t oid, uint32_t epoch, char *path,
 int tree_get_hash(uint64_t oid, uint32_t epoch, uint8_t *sha1)
 {
 	int ret;
-	void *buf;
+	void *buf = NULL;
 	struct siocb iocb = {};
 	uint32_t length;
 	bool is_readonly_obj = oid_is_readonly(oid);
@@ -681,8 +681,8 @@ int tree_get_hash(uint64_t oid, uint32_t epoch, uint8_t *sha1)
 	}
 
 	length = get_store_objsize(oid);
-	buf = valloc(length);
-	if (buf == NULL)
+	ret = posix_memalign((void **)&buf, getpagesize(), length);
+	if (ret)
 		return SD_RES_NO_MEM;
 
 	iocb.epoch = epoch;


### PR DESCRIPTION
We should use posix_memalign() instead of valloc().

Signed-off-by: Hitoshi Mitake <mitake.hitoshi@lab.ntt.co.jp>