### PR TITLE
docs: fix simple typo, exmple -> example

### DIFF
--- a/doc/how_to_upload_packages.rst
+++ b/doc/how_to_upload_packages.rst
@@ -30,7 +30,7 @@ Compile-time dependencies:
 
 2. Make Package
 -----------------
-Here is just an exmple with sheepdog-1.0.1.tar.gz.
+Here is just an example with sheepdog-1.0.1.tar.gz.
 
 Replace source-code file which answers your purpose.
 


### PR DESCRIPTION
There is a small typo in doc/how_to_upload_packages.rst.

Should read `example` rather than `exmple`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md